### PR TITLE
trees/tiles: Add TileReader and ReadEntries

### DIFF
--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -39,12 +39,18 @@ import (
 // ErrTileExists is returned when trying to write a tile that already exists in storage.
 var ErrTileExists = errors.New("tile exists")
 
-// simpleS3 matches the subset of the bs3.Client interface which we use, to allow
-// simpler mocking in tests.
-type simpleS3 interface {
-	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+// simpleS3Reader matches the subset of the bs3.Client interface which reads
+// use, to allow simpler mocking in tests.
+type simpleS3Reader interface {
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	Bucket() string
+}
+
+// simpleS3 matches the subset of the bs3.Client interface which writes use, to
+// allow simpler mocking in tests.
+type simpleS3 interface {
+	simpleS3Reader
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 }
 
 // Frontier contains all the tiles on the right edge of the tree,
@@ -171,7 +177,7 @@ func (e *entryTile) append(val []byte) {
 // LoadFrontier loads the current frontier from storage, given the current tree size.
 //
 // Succeeds only if all the frontier tiles for that tree size exist in storage.
-func LoadFrontier(ctx context.Context, s3c simpleS3, treeSize int64, prefix string) (*Frontier, error) {
+func LoadFrontier(ctx context.Context, s3c simpleS3Reader, treeSize int64, prefix string) (*Frontier, error) {
 	if treeSize == 0 {
 		return nil, fmt.Errorf("can't load an empty tree")
 	}
@@ -583,7 +589,7 @@ func tilePath(coords tlog.Tile) string {
 // getTile fetches a single tile from storage, transparently decompressing if needed.
 //
 // If coords.W is zero, returns an empty tile without reading from storage.
-func getTile(ctx context.Context, s3c simpleS3, coords tlog.Tile, prefix string) ([]byte, error) {
+func getTile(ctx context.Context, s3c simpleS3Reader, coords tlog.Tile, prefix string) ([]byte, error) {
 	if coords.W == 0 {
 		// Neither write nor read an empty tile. They do not exist in storage.
 		return nil, nil
@@ -627,4 +633,87 @@ func getTile(ctx context.Context, s3c simpleS3, coords tlog.Tile, prefix string)
 	}
 
 	return body, nil
+}
+
+// TileReader reads stored hash tiles as a tlog.TileReader, for use with
+// tlog.TileHashReader.
+type TileReader struct {
+	// ctx is used for storage reads because tlog.TileReader's methods have no
+	// context parameters.
+	ctx    context.Context
+	s3c    simpleS3Reader
+	prefix string
+}
+
+// NewTileReader returns a TileReader over the tiles stored under prefix.
+func NewTileReader(ctx context.Context, s3c simpleS3Reader, prefix string) *TileReader {
+	return &TileReader{ctx: ctx, s3c: s3c, prefix: prefix}
+}
+
+// Height returns 8, the height of tiles holding 256 hashes.
+func (r *TileReader) Height() int {
+	return 8
+}
+
+// ReadTiles fetches the data for each requested tile from storage.
+func (r *TileReader) ReadTiles(tiles []tlog.Tile) ([][]byte, error) {
+	data := make([][]byte, len(tiles))
+	for i, coords := range tiles {
+		body, err := getTile(r.ctx, r.s3c, coords, r.prefix)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(body) != coords.W*tlog.HashSize {
+			return nil, fmt.Errorf("%q: got %d bytes, expected %d",
+				tilePath(coords), len(body), coords.W*tlog.HashSize)
+		}
+
+		data[i] = body
+	}
+	return data, nil
+}
+
+// SaveTiles is a no-op.
+func (r *TileReader) SaveTiles([]tlog.Tile, [][]byte) {}
+
+// ReadEntries reads the marshaled log entries in [start, end) from the entry
+// bundles stored under prefix. treeSize determines the rightmost bundle's
+// width, and so its path.
+func ReadEntries(ctx context.Context, s3c simpleS3Reader, start, end, treeSize int64, prefix string) ([][]byte, error) {
+	if start < 0 || start >= end || end > treeSize {
+		return nil, fmt.Errorf("invalid entry interval [%d, %d) for tree size %d", start, end, treeSize)
+	}
+	var entries [][]byte
+	for bundle := start / 256; bundle*256 < end; bundle++ {
+		width := min(int64(256), treeSize-bundle*256)
+		coords := tlog.Tile{
+			L: -1, // entries layer is represented as -1.
+			N: bundle,
+			W: int(width),
+		}
+
+		body, err := getTile(ctx, s3c, coords, prefix)
+		if err != nil {
+			return nil, err
+		}
+
+		br := entry.NewBundleReader(body)
+		for i := bundle * 256; ; i++ {
+			_, raw, err := br.ReadEntry()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return nil, fmt.Errorf("parsing entries: %s", err)
+			}
+			if i >= start && i < end {
+				entries = append(entries, raw)
+			}
+		}
+	}
+	if int64(len(entries)) != end-start {
+		return nil, fmt.Errorf("reading entries [%d, %d): got %d entries, want %d", start, end, len(entries), end-start)
+	}
+	return entries, nil
 }

--- a/trees/tiles/tiles.go
+++ b/trees/tiles/tiles.go
@@ -30,6 +30,7 @@ import (
 
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/mod/sumdb/tlog"
 
 	"github.com/letsencrypt/boulder/trees/entry"
@@ -657,8 +658,8 @@ func (r *TileReader) Height() int {
 
 // ReadTiles fetches the data for each requested tile from storage.
 func (r *TileReader) ReadTiles(tiles []tlog.Tile) ([][]byte, error) {
-	data := make([][]byte, len(tiles))
-	for i, coords := range tiles {
+	var data [][]byte
+	for _, coords := range tiles {
 		body, err := getTile(r.ctx, r.s3c, coords, r.prefix)
 		if err != nil {
 			return nil, err
@@ -669,7 +670,7 @@ func (r *TileReader) ReadTiles(tiles []tlog.Tile) ([][]byte, error) {
 				tilePath(coords), len(body), coords.W*tlog.HashSize)
 		}
 
-		data[i] = body
+		data = append(data, body)
 	}
 	return data, nil
 }
@@ -677,43 +678,40 @@ func (r *TileReader) ReadTiles(tiles []tlog.Tile) ([][]byte, error) {
 // SaveTiles is a no-op.
 func (r *TileReader) SaveTiles([]tlog.Tile, [][]byte) {}
 
-// ReadEntries reads the marshaled log entries in [start, end) from the entry
-// bundles stored under prefix. treeSize determines the rightmost bundle's
-// width, and so its path.
-func ReadEntries(ctx context.Context, s3c simpleS3Reader, start, end, treeSize int64, prefix string) ([][]byte, error) {
+// EntriesForPackage reads the entries in [start, end) from their stored entry
+// bundle, returning them unparsed in the wire form a tlog-mirror entry package
+// requires, each entry with a big-endian uint16 length prefix.
+//
+// https://c2sp.org/tlog-mirror
+func EntriesForPackage(ctx context.Context, s3c simpleS3Reader, start, end, treeSize int64, prefix string) ([]byte, error) {
 	if start < 0 || start >= end || end > treeSize {
 		return nil, fmt.Errorf("invalid entry interval [%d, %d) for tree size %d", start, end, treeSize)
 	}
-	var entries [][]byte
-	for bundle := start / 256; bundle*256 < end; bundle++ {
-		width := min(int64(256), treeSize-bundle*256)
-		coords := tlog.Tile{
-			L: -1, // entries layer is represented as -1.
-			N: bundle,
-			W: int(width),
-		}
+	bundle := start / 256
+	if (end-1)/256 != bundle {
+		return nil, fmt.Errorf("entry interval [%d, %d) spans multiple bundles", start, end)
+	}
+	coords := tlog.Tile{
+		L: -1, // entries layer is represented as -1.
+		N: bundle,
+		W: int(min(int64(256), treeSize-bundle*256)),
+	}
 
-		body, err := getTile(ctx, s3c, coords, prefix)
-		if err != nil {
-			return nil, err
-		}
+	body, err := getTile(ctx, s3c, coords, prefix)
+	if err != nil {
+		return nil, err
+	}
 
-		br := entry.NewBundleReader(body)
-		for i := bundle * 256; ; i++ {
-			_, raw, err := br.ReadEntry()
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				return nil, fmt.Errorf("parsing entries: %s", err)
-			}
-			if i >= start && i < end {
-				entries = append(entries, raw)
-			}
+	rest := cryptobyte.String(body)
+	var entriesBegin int
+	var entryData cryptobyte.String
+	for i := bundle * 256; i < end; i++ {
+		if i == start {
+			entriesBegin = len(body) - len(rest)
+		}
+		if !rest.ReadUint16LengthPrefixed(&entryData) {
+			return nil, fmt.Errorf("%q unexpectedly truncated at entry %d", tilePath(coords), i)
 		}
 	}
-	if int64(len(entries)) != end-start {
-		return nil, fmt.Errorf("reading entries [%d, %d): got %d entries, want %d", start, end, len(entries), end-start)
-	}
-	return entries, nil
+	return body[entriesBegin : len(body)-len(rest)], nil
 }

--- a/trees/tiles/tiles_test.go
+++ b/trees/tiles/tiles_test.go
@@ -476,7 +476,7 @@ func TestClone(t *testing.T) {
 	// Append more than one full tile's worth of entries, to exercise
 	// fullHashesTiles and fullEntryTiles.
 	frontier := &Frontier{}
-	for i := 0; i < 260; i++ {
+	for i := range 260 {
 		err := frontier.AppendEntry(testEntry(i))
 		if err != nil {
 			t.Fatalf("AppendEntry(%d): %s", i, err)
@@ -534,5 +534,98 @@ func TestClone(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fs3f.Objects, fs3c.Objects) {
 		t.Errorf("original and clone published different tiles")
+	}
+}
+
+const testPrefix = "44947.4.1/44"
+
+// publishedTree appends n null entries to an empty log in fs3 and publishes
+// it, returning the resulting tree.
+func publishedTree(t *testing.T, fs3 *bs3test.FakeS3, n int64) tlog.Tree {
+	t.Helper()
+	f := &Frontier{}
+	for range n {
+		err := f.AppendEntry(&entry.MTCLogEntry{})
+		if err != nil {
+			t.Fatalf("AppendEntry: %s", err)
+		}
+	}
+	err := f.Publish(t.Context(), fs3, testPrefix)
+	if err != nil {
+		t.Fatalf("Publish: %s", err)
+	}
+	return tlog.Tree{N: f.TreeSize(), Hash: f.RootHash()}
+}
+
+// TestTileReaderTreeHash checks that hashes read through TileReader
+// reconstruct the published root, for both partial and full rightmost tiles,
+// and after a log grows past tiles it published as partial.
+func TestTileReaderTreeHash(t *testing.T) {
+	for _, size := range []int64{1, 5, 256, 700} {
+		fs3 := bs3test.New()
+		tree := publishedTree(t, fs3, size)
+		hash, err := tlog.TreeHash(tree.N, tlog.TileHashReader(tree, NewTileReader(t.Context(), fs3, testPrefix)))
+		if err != nil {
+			t.Fatalf("TreeHash at size %d: %s", size, err)
+		}
+		if hash != tree.Hash {
+			t.Errorf("TreeHash at size %d = %v, want %v", size, hash, tree.Hash)
+		}
+	}
+
+	fs3 := bs3test.New()
+	f := &Frontier{}
+	appendEntries(t, f, fs3, 0, 300, testPrefix, 300)
+	appendEntries(t, f, fs3, 300, 700, testPrefix, 400)
+	tree := tlog.Tree{N: f.TreeSize(), Hash: f.RootHash()}
+	hash, err := tlog.TreeHash(tree.N, tlog.TileHashReader(tree, NewTileReader(t.Context(), fs3, testPrefix)))
+	if err != nil {
+		t.Fatalf("TreeHash after growth: %s", err)
+	}
+	if hash != tree.Hash {
+		t.Errorf("TreeHash after growth = %v, want %v", hash, tree.Hash)
+	}
+}
+
+// TestReadEntries checks reading entry intervals back from stored bundles,
+// including intervals that straddle a bundle boundary, returning each entry
+// at its own index.
+func TestReadEntries(t *testing.T) {
+	fs3 := bs3test.New()
+	f := buildFrontier(t, fs3, 700, testPrefix, 700)
+	treeSize := f.TreeSize()
+
+	for _, tc := range []struct{ start, end int64 }{
+		{0, 700},
+		{0, 1},
+		{255, 257},
+		{512, 700},
+		{699, 700},
+	} {
+		entries, err := ReadEntries(t.Context(), fs3, tc.start, tc.end, treeSize, testPrefix)
+		if err != nil {
+			t.Fatalf("ReadEntries(%d, %d): %s", tc.start, tc.end, err)
+		}
+		if int64(len(entries)) != tc.end-tc.start {
+			t.Fatalf("ReadEntries(%d, %d) returned %d entries", tc.start, tc.end, len(entries))
+		}
+		for i, e := range entries {
+			want := testEntryBody(int(tc.start) + i)
+			if !bytes.Equal(e, want) {
+				t.Fatalf("ReadEntries(%d, %d) entry %d = %x, want %x", tc.start, tc.end, int(tc.start)+i, e, want)
+			}
+		}
+	}
+
+	for _, tc := range []struct{ start, end int64 }{
+		{-1, 5},
+		{5, 5},
+		{6, 5},
+		{0, 701},
+	} {
+		_, err := ReadEntries(t.Context(), fs3, tc.start, tc.end, treeSize, testPrefix)
+		if err == nil {
+			t.Errorf("ReadEntries(%d, %d) = nil error, want error", tc.start, tc.end)
+		}
 	}
 }

--- a/trees/tiles/tiles_test.go
+++ b/trees/tiles/tiles_test.go
@@ -587,33 +587,32 @@ func TestTileReaderTreeHash(t *testing.T) {
 	}
 }
 
-// TestReadEntries checks reading entry intervals back from stored bundles,
-// including intervals that straddle a bundle boundary, returning each entry
-// at its own index.
-func TestReadEntries(t *testing.T) {
+// TestEntriesForPackage checks reading entry intervals back from stored
+// bundles in wire form, from both full and partial bundles, and that invalid
+// and bundle-spanning intervals are rejected.
+func TestEntriesForPackage(t *testing.T) {
 	fs3 := bs3test.New()
 	f := buildFrontier(t, fs3, 700, testPrefix, 700)
 	treeSize := f.TreeSize()
 
 	for _, tc := range []struct{ start, end int64 }{
-		{0, 700},
+		{0, 256},
 		{0, 1},
-		{255, 257},
+		{200, 256},
 		{512, 700},
+		{520, 600},
 		{699, 700},
 	} {
-		entries, err := ReadEntries(t.Context(), fs3, tc.start, tc.end, treeSize, testPrefix)
+		entries, err := EntriesForPackage(t.Context(), fs3, tc.start, tc.end, treeSize, testPrefix)
 		if err != nil {
-			t.Fatalf("ReadEntries(%d, %d): %s", tc.start, tc.end, err)
+			t.Fatalf("EntriesForPackage(%d, %d): %s", tc.start, tc.end, err)
 		}
-		if int64(len(entries)) != tc.end-tc.start {
-			t.Fatalf("ReadEntries(%d, %d) returned %d entries", tc.start, tc.end, len(entries))
+		var expect []byte
+		for i := tc.start; i < tc.end; i++ {
+			expect = append(expect, bundledEntry(testEntryBody(int(i)))...)
 		}
-		for i, e := range entries {
-			want := testEntryBody(int(tc.start) + i)
-			if !bytes.Equal(e, want) {
-				t.Fatalf("ReadEntries(%d, %d) entry %d = %x, want %x", tc.start, tc.end, int(tc.start)+i, e, want)
-			}
+		if !bytes.Equal(entries, expect) {
+			t.Fatalf("EntriesForPackage(%d, %d) = %x, want %x", tc.start, tc.end, entries, expect)
 		}
 	}
 
@@ -621,11 +620,12 @@ func TestReadEntries(t *testing.T) {
 		{-1, 5},
 		{5, 5},
 		{6, 5},
-		{0, 701},
+		{699, 701},
+		{255, 257},
 	} {
-		_, err := ReadEntries(t.Context(), fs3, tc.start, tc.end, treeSize, testPrefix)
+		_, err := EntriesForPackage(t.Context(), fs3, tc.start, tc.end, treeSize, testPrefix)
 		if err == nil {
-			t.Errorf("ReadEntries(%d, %d) = nil error, want error", tc.start, tc.end)
+			t.Errorf("EntriesForPackage(%d, %d) = nil error, want error", tc.start, tc.end)
 		}
 	}
 }


### PR DESCRIPTION
Also, narrow the interface for the s3c used on read-only trees/tiles functions.

Closes https://github.com/letsencrypt/boulder/issues/8946