### PR TITLE
genmtpki: remove SubjectKeyId

### DIFF
--- a/test/certs/genmtpki/genmtpki.go
+++ b/test/certs/genmtpki/genmtpki.go
@@ -69,11 +69,6 @@ func main2() error {
 		// TODO: decide how to generate serial number for MTCA certificates; presumably random?
 		SerialNumber: big.NewInt(123),
 		Subject:      mtcaSubject(),
-		// CA ID, encoded
-		// https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-representing-certification-
-		// The subject key identifier extension, if present, SHOULD be set to the CA ID (Section 5.1).
-		// The CA ID is encoded in its binary representation, as defined in Section 3 of [I-D.ietf-tls-trust-anchor-ids].
-		SubjectKeyId: []byte{0x82, 0xdf, 0x13, 1, 2, 1},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
 		// The key usage extension (Section 4.2.1.3 of [RFC5280]) MUST be present and assert at least the keyCertSign bit.


### PR DESCRIPTION
This extension is required by the BR Root CA Certificate Profile, but that's not relevant here: MTC CA Cosigner certificates need to follow the CQRP profile, which references the MTC spec profile, where the extension is optional.

https://googlechrome.github.io/chromerootprogram/cqrp/draft-policy/#2431-mtc-ca-cosigner-certificate-profile

https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-representing-certification-

https://cabforum.org/working-groups/server/baseline-requirements/requirements/#71212-root-ca-extensions

Part of #8920.