### PR TITLE
va: Match CAA parameter tags case insensitively

### DIFF
--- a/va/caa.go
+++ b/va/caa.go
@@ -494,7 +494,12 @@ func caaAccountURIMatches(caaParams []caaParameter, accountURIPrefixes []string,
 	var found bool
 	var accountURI string
 	for _, c := range caaParams {
-		if c.tag == "accounturi" {
+		// RFC 8659 Section 4.1 makes matching of Property Tags case insensitive but
+		// specifies no comparison rule for parameter tags. We lowercase the parameter
+		// tag as a safety choice: treating a differently-cased "accounturi" as an
+		// unrecognized parameter would drop the restriction the subscriber intended
+		// and make this Property match any account, a false-positive validation.
+		if strings.ToLower(c.tag) == "accounturi" {
 			if found {
 				// A Property with multiple "accounturi" parameters is
 				// unsatisfiable.
@@ -536,7 +541,8 @@ func caaValidationMethodMatches(caaParams []caaParameter, method core.AcmeChalle
 	var validationMethods string
 	var found bool
 	for _, param := range caaParams {
-		if param.tag == "validationmethods" {
+		// Match the parameter tag case insensitively, as in caaAccountURIMatches.
+		if strings.ToLower(param.tag) == "validationmethods" {
 			if found {
 				// RFC 8657 does not define what behavior to take when multiple
 				// "validationmethods" parameters exist, but we make the

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -1421,6 +1421,24 @@ func TestAccountURIMatches(t *testing.T) {
 			id:   654321,
 			want: false,
 		},
+		{
+			name:   "mixed-case tag matches the expected account",
+			params: []caaParameter{{tag: "AccountURI", val: "https://acme-v02.api.letsencrypt.org/acme/acct/123456"}},
+			prefixes: []string{
+				"https://acme-v02.api.letsencrypt.org/acme/acct/",
+			},
+			id:   123456,
+			want: true,
+		},
+		{
+			name:   "mixed-case tag still restricts a non-matching account",
+			params: []caaParameter{{tag: "AccountURI", val: "https://acme-v02.api.letsencrypt.org/acme/acct/123456"}},
+			prefixes: []string{
+				"https://acme-v02.api.letsencrypt.org/acme/acct/",
+			},
+			id:   654321,
+			want: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1534,6 +1552,18 @@ func TestValidationMethodMatches(t *testing.T) {
 			name:   "multiple choices, match none",
 			params: []caaParameter{{tag: "validationmethods", val: "http-01,dns-01"}},
 			method: core.ChallengeTypeTLSALPN01,
+			want:   false,
+		},
+		{
+			name:   "mixed-case tag matches the method in use",
+			params: []caaParameter{{tag: "ValidationMethods", val: "dns-01"}},
+			method: core.ChallengeTypeDNS01,
+			want:   true,
+		},
+		{
+			name:   "mixed-case tag still restricts a non-matching method",
+			params: []caaParameter{{tag: "ValidationMethods", val: "dns-01"}},
+			method: core.ChallengeTypeHTTP01,
 			want:   false,
 		},
 	}


### PR DESCRIPTION
This makes the `accounturi` and `validationmethods` CAA parameter tags match case insensitively, so a differently cased tag such as `AccountURI` or `ValidationMethods` still restricts issuance instead of being treated as an unrecognized parameter.

From https://www.rfc-editor.org/rfc/rfc8659#section-4.1, stated for Property Tags:

> Matching of tags is case insensitive.

That rule covers Property Tags (`issue`, `issuewild`, and so on). For the parameter tags carried inside an `issue` value, neither RFC 8659 nor RFC 8657 defines a comparison rule. 

`caaAccountURIMatches` and `caaValidationMethodMatches` currently compare the parameter tag with `==` against the lowercase literals `"accounturi"` and `"validationmethods"`. A differently cased tag does not match, so it is treated as an unrecognized parameter and the restriction is dropped. For `accounturi` the Property then matches any account, and for `validationmethods` any validation method is accepted, so in both cases a domain that intended to restrict issuance gets a false positive validation.

For reference, the same case being discussed in the PR for RFC 8657 support in the Open MPIC project, https://github.com/open-mpic/open-mpic-core-python/pull/71#discussion_r3798619258
