### PR TITLE
va: Validate CAA parameter tags per RFC 8659

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,9 +68,7 @@ linters:
       checks:
         - all
         # TODO: Identify, fix, and remove violations of most of these rules
-        - -S1029  # Range over the string directly
         - -SA1019 # Using a deprecated function, variable, constant or field
-        - -SA6003 # Converting a string to a slice of runes before ranging over it
         - -ST1000 # Incorrect or missing package comment
         - -ST1003 # Poorly chosen identifier
         - -ST1005 # Incorrectly formatted error string

--- a/va/caa.go
+++ b/va/caa.go
@@ -416,6 +416,10 @@ type caaParameter struct {
 // tag = (ALPHA / DIGIT) *( *("-") (ALPHA / DIGIT))
 var caaParameterTagRegexp = regexp.MustCompile(`^[[:alnum:]](-*[[:alnum:]])*$`)
 
+// ASCII without whitespace/semi-colons.
+// value = *(%x21-3A / %x3C-7E)
+var caaParameterValueRegexp = regexp.MustCompile(`^[\x21-\x3a\x3c-\x7e]*$`)
+
 // parseCAARecord extracts the domain and parameters (if any) from a
 // issue/issuewild CAA record. This follows RFC 8659 Section 4.2 and Section 4.3
 // (https://www.rfc-editor.org/rfc/rfc8659.html#section-4). It returns the
@@ -459,13 +463,8 @@ func parseCAARecord(caa *dns.CAA) (string, []caaParameter, error) {
 		}
 
 		value := strings.TrimFunc(tv[1], isWSP)
-		//lint:ignore S1029,SA6003 we iterate over runes because the RFC specifies ascii codepoints.
-		for _, r := range []rune(value) {
-			// ASCII without whitespace/semi-colons.
-			// value = *(%x21-3A / %x3C-7E)
-			if r < 0x21 || (r > 0x3a && r < 0x3c) || r > 0x7e {
-				return "", nil, fmt.Errorf("value contains disallowed character: %q", value)
-			}
+		if !caaParameterValueRegexp.MatchString(value) {
+			return "", nil, fmt.Errorf("value contains disallowed character: %q", value)
 		}
 
 		caaParameters = append(caaParameters, caaParameter{

--- a/va/caa.go
+++ b/va/caa.go
@@ -412,6 +412,10 @@ type caaParameter struct {
 	val string
 }
 
+// ASCII alpha, digits, and hyphens in the middle.
+// tag = (ALPHA / DIGIT) *( *("-") (ALPHA / DIGIT))
+var caaParameterTagRegexp = regexp.MustCompile(`^[[:alnum:]](-*[[:alnum:]])*$`)
+
 // parseCAARecord extracts the domain and parameters (if any) from a
 // issue/issuewild CAA record. This follows RFC 8659 Section 4.2 and Section 4.3
 // (https://www.rfc-editor.org/rfc/rfc8659.html#section-4). It returns the
@@ -450,13 +454,8 @@ func parseCAARecord(caa *dns.CAA) (string, []caaParameter, error) {
 		}
 
 		tag := strings.TrimFunc(tv[0], isWSP)
-		//lint:ignore S1029,SA6003 we iterate over runes because the RFC specifies ascii codepoints.
-		for _, r := range []rune(tag) {
-			// ASCII alpha/digits.
-			// tag = (ALPHA / DIGIT) *( *("-") (ALPHA / DIGIT))
-			if r < 0x30 || (r > 0x39 && r < 0x41) || (r > 0x5a && r < 0x61) || r > 0x7a {
-				return "", nil, fmt.Errorf("tag contains disallowed character: %q", tag)
-			}
+		if !caaParameterTagRegexp.MatchString(tag) {
+			return "", nil, fmt.Errorf("tag contains disallowed character: %q", tag)
 		}
 
 		value := strings.TrimFunc(tv[1], isWSP)

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -1704,6 +1704,16 @@ func TestExtractIssuerDomainAndParameters(t *testing.T) {
 			expectErrSubstr: "tag contains disallowed character",
 		},
 		{
+			name:            "empty param tag is invalid",
+			value:           "letsencrypt.org; =c",
+			expectErrSubstr: "tag contains disallowed character",
+		},
+		{
+			name:            "empty param tag between valid params is invalid",
+			value:           "letsencrypt.org; a=b; =c",
+			expectErrSubstr: "tag contains disallowed character",
+		},
+		{
 			name:            "high codepoints in params are invalid",
 			value:           "letsencrypt.org; foo=a\u2615b",
 			expectErrSubstr: "value contains disallowed character",

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -1673,8 +1673,34 @@ func TestExtractIssuerDomainAndParameters(t *testing.T) {
 			expectErrSubstr: "value contains disallowed character",
 		},
 		{
-			name:            "hyphens in param tags are invalid",
+			name:            "interior hyphens in param tags are valid",
 			value:           "letsencrypt.org; 1=2; a-b=c",
+			wantDomain:      "letsencrypt.org",
+			wantParameters:  []caaParameter{{tag: "1", val: "2"}, {tag: "a-b", val: "c"}},
+			expectErrSubstr: "",
+		},
+		{
+			name:            "multiple interior hyphens in param tags are valid",
+			value:           "letsencrypt.org; 1=2; a-b-c=d",
+			wantDomain:      "letsencrypt.org",
+			wantParameters:  []caaParameter{{tag: "1", val: "2"}, {tag: "a-b-c", val: "d"}},
+			expectErrSubstr: "",
+		},
+		{
+			name:            "consecutive interior hyphens in param tags are valid",
+			value:           "letsencrypt.org; a--b=c",
+			wantDomain:      "letsencrypt.org",
+			wantParameters:  []caaParameter{{tag: "a--b", val: "c"}},
+			expectErrSubstr: "",
+		},
+		{
+			name:            "leading hyphen in param tag is invalid",
+			value:           "letsencrypt.org; -ab=c",
+			expectErrSubstr: "tag contains disallowed character",
+		},
+		{
+			name:            "trailing hyphen in param tag is invalid",
+			value:           "letsencrypt.org; ab-=c",
 			expectErrSubstr: "tag contains disallowed character",
 		},
 		{


### PR DESCRIPTION
`parseCAARecord`'s character check rejects hyphens in a parameter tag, which matches the narrower RFC 6844 grammar rather than the RFC 8659 one it should follow.

From https://www.rfc-editor.org/rfc/rfc6844#section-5.2:

```
tag = 1*(ALPHA / DIGIT)
```

From https://www.rfc-editor.org/rfc/rfc8659#section-4.2:

```
tag = (ALPHA / DIGIT) *( *("-") (ALPHA / DIGIT))
```

The character check excludes 0x2D, so an extra hyphenated tag makes the whole record fail to parse and the caller skips it. If that was the record authorizing the CA, a request the CAA records actually authorize is denied. This simply can block a Subscriber from getting a certificate.

The same check is also too lenient in the other direction: it accepts an empty tag, because the character loop runs zero times over an empty string. An empty tag is an RFC violation, since RFC 8659 `tag` requires at least one character.

This last one is especially problematic and could have produced misissuances (didn't test myself to avoid the hassle of a Bugzilla Bug), because the TBRs require RFC 8659 adherence and RFC 8659 Section 4.2 says:

> An issue Property Tag where the issue-value does not match the ABNF grammar MUST be treated the same as one specifying an empty issuer-domain-name.

An empty issuer-domain-name authorizes no issuer, so whether a value is judged to match the grammar decides whether issuance is allowed.

Validating the tag with a regexp for the RFC 8659 grammar corrects both of the previous issues: interior hyphens are accepted, and leading hyphens, trailing hyphens, and empty tags are rejected.

For consistency the parameter value is validated with a regexp too. That part is separable and can be left out.

On performance, a regexp is slower than the hand-rolled loops, but I think that is not significant here, since CAA checking is dominated by the DNS lookups. For the tag, a loop matching the RFC 8659 grammar is also not very concise.

Finally, as mentioned earlier in https://github.com/letsencrypt/boulder/pull/8975#issuecomment-5411649079, it might be a good idea to implement this parsing logic in a single place and share it with the Persistent DCV method.
