### PR TITLE
bad-key-revoker: earlier check for too many affected certs

### DIFF
--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -163,10 +163,11 @@ func (bkr *badKeyRevoker) findUnrevoked(ctx context.Context, unchecked unchecked
 			}
 			unrevokedCerts = append(unrevokedCerts, unrevokedCert)
 		}
+		if len(unrevokedCerts) > bkr.maxRevocations {
+			return nil, fmt.Errorf("too many certificates to revoke associated with %x: got %d, max %d", unchecked.KeyHash, len(unrevokedCerts), bkr.maxRevocations)
+		}
 	}
-	if len(unrevokedCerts) > bkr.maxRevocations {
-		return nil, fmt.Errorf("too many certificates to revoke associated with %x: got %d, max %d", unchecked.KeyHash, len(unrevokedCerts), bkr.maxRevocations)
-	}
+
 	return unrevokedCerts, nil
 }
 

--- a/cmd/bad-key-revoker/main.go
+++ b/cmd/bad-key-revoker/main.go
@@ -164,7 +164,7 @@ func (bkr *badKeyRevoker) findUnrevoked(ctx context.Context, unchecked unchecked
 			unrevokedCerts = append(unrevokedCerts, unrevokedCert)
 		}
 		if len(unrevokedCerts) > bkr.maxRevocations {
-			return nil, fmt.Errorf("too many certificates to revoke associated with %x: got %d, max %d", unchecked.KeyHash, len(unrevokedCerts), bkr.maxRevocations)
+			return nil, fmt.Errorf("too many certificates to revoke associated with %x: found at least %d, max %d", unchecked.KeyHash, len(unrevokedCerts), bkr.maxRevocations)
 		}
 	}
 

--- a/cmd/bad-key-revoker/main_test.go
+++ b/cmd/bad-key-revoker/main_test.go
@@ -262,7 +262,7 @@ func TestFindUnrevoked(t *testing.T) {
 	bkr.maxRevocations = 0
 	_, err = bkr.findUnrevoked(ctx, uncheckedBlockedKey{KeyHash: hashA})
 	test.AssertError(t, err, "findUnrevoked didn't fail with 0 maxRevocations")
-	test.AssertEquals(t, err.Error(), fmt.Sprintf("too many certificates to revoke associated with %x: got 1, max 0", hashA))
+	test.AssertEquals(t, err.Error(), fmt.Sprintf("too many certificates to revoke associated with %x: found at least 1, max 0", hashA))
 }
 
 type mockRevoker struct {


### PR DESCRIPTION
The bad-key-revoker refuses to process a row if the resulting affected certificate set is going to be too large: in such cases, we want the revocation to be manually reviewed. However, it currently computes the full affected certificate set before ever comparing the size of that set to the threshold. This means that it could spend excessive database time querying for affected certificates even when it already knows that it won't proceed with automated revocation.

Move the check against the maxRevocations threshold inside the loop, so it will bail out earlier in such cases.