### PR TITLE
golangci: Address lints raised by building with go1.27.0.

### DIFF
--- a/mtca/mtca_test.go
+++ b/mtca/mtca_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/jmhodges/clock"
+
 	"github.com/letsencrypt/borp"
 
 	"github.com/letsencrypt/boulder/bs3/bs3test"
@@ -64,7 +65,10 @@ func setup() (*mtca, *bs3test.FakeS3, func(), error) {
 		return nil, nil, nil, err
 	}
 	dbMap := &borp.DbMap{Db: db, Dialect: borp.MySQLDialect{}}
-	truncateTables(db)
+	err = truncateTables(db)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 
 	logger := blog.NewMock()
 	clk := clock.NewFake()
@@ -107,7 +111,7 @@ func setup() (*mtca, *bs3test.FakeS3, func(), error) {
 	}
 
 	cleanup := func() {
-		truncateTables(db)
+		_ = truncateTables(db)
 	}
 
 	return mtca, fs3, cleanup, nil
@@ -184,9 +188,16 @@ func TestCheckpointValid(t *testing.T) {
 	}
 }
 
-func truncateTables(db *sql.DB) {
-	db.Exec("TRUNCATE TABLE checkpoints")
-	db.Exec("TRUNCATE TABLE latestCheckpoint")
+func truncateTables(db *sql.DB) error {
+	_, err := db.Exec("TRUNCATE TABLE checkpoints")
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("TRUNCATE TABLE latestCheckpoint")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // issueResult is the outcome of one async Issue call, along with the values
@@ -543,7 +554,7 @@ func verifyCheckpoint(t *testing.T, mtca *mtca, checkpoint *checkpoint) {
 		Timestamp:    0,
 		LogOrigin:    mtca.logID.Origin(),
 		Start:        0,
-		End:          uint64(checkpoint.TreeSize),
+		End:          uint64(checkpoint.TreeSize), //nolint:gosec // G115: we know that tree sizes are positive in these tests
 		SubtreeHash:  [32]byte(checkpoint.RootHash),
 	}
 

--- a/trees/cosignature/cosignature_test.go
+++ b/trees/cosignature/cosignature_test.go
@@ -16,10 +16,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/letsencrypt/boulder/privatekey"
-	"github.com/letsencrypt/boulder/trees/checkpoint"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/mod/sumdb/tlog"
+
+	"github.com/letsencrypt/boulder/privatekey"
+	"github.com/letsencrypt/boulder/trees/checkpoint"
 )
 
 // exampleCheckpoint is a canonical tlog-checkpoint note body the cosignature
@@ -382,7 +383,7 @@ func TestCosignerPropagatesSignerError(t *testing.T) {
 func TestRawSignature(t *testing.T) {
 	timestampedSignature := make([]byte, timestampedSignatureSize)
 	for i := range timestampedSignature[8:] {
-		timestampedSignature[8+i] = byte(i)
+		timestampedSignature[8+i] = byte(i) //nolint:gosec // G602 false positive on slice index
 	}
 	signature, err := RawSignature(timestampedSignature)
 	if err != nil {


### PR DESCRIPTION
Some lints were not raised when golanci-lint was built with go1.26.6. After building the tool with go1.27.0, these new lints were raised.