### PR TITLE
add treedb package

### DIFF
--- a/mtca/mtca.go
+++ b/mtca/mtca.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/mldsa"
-	"crypto/sha256"
 	"crypto/x509"
-	"database/sql"
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
@@ -33,6 +31,7 @@ import (
 	"github.com/letsencrypt/boulder/trees/entry"
 	"github.com/letsencrypt/boulder/trees/issuancelog"
 	"github.com/letsencrypt/boulder/trees/tiles"
+	"github.com/letsencrypt/boulder/trees/treedb"
 )
 
 var ErrIssuanceLogAlreadyInitialized = errors.New("issuance log already initialized")
@@ -148,7 +147,7 @@ func getCAID(issuerCert *x509.Certificate) (string, error) {
 }
 
 func initDB(dbMap *borp.DbMap) *db.WrappedMap {
-	dbMap.AddTableWithName(checkpoint{}, "checkpoints").SetKeys(true, "ID")
+	dbMap.AddTableWithName(treedb.CheckpointModel{}, "checkpoints").SetKeys(true, "ID")
 	return db.NewWrappedMap(dbMap)
 }
 
@@ -189,20 +188,20 @@ func (m *mtca) InitLog(ctx context.Context) error {
 				m.logID.String(), numCheckpoints, numLatestCheckpoints)
 		}
 
-		firstCheckpoint := checkpoint{
+		firstCheckpoint := &treedb.CheckpointModel{
 			MTCLogID: m.logID.String(),
 			TreeSize: candidate.TreeSize(),
 			RootHash: rootHash[:],
 		}
 
-		caSig, err := m.signCheckpoint(&firstCheckpoint)
+		caSig, err := m.signCheckpoint(firstCheckpoint)
 		if err != nil {
 			return nil, err
 		}
 
 		firstCheckpoint.MTCASignature = caSig
 
-		err = tx.Insert(ctx, &firstCheckpoint)
+		err = tx.Insert(ctx, firstCheckpoint)
 		if err != nil {
 			return nil, err
 		}
@@ -234,7 +233,7 @@ func (m *mtca) InitLog(ctx context.Context) error {
 
 	m.frontier = candidate
 
-	_, err = m.latestCheckpoint(ctx)
+	_, err = treedb.New(m.db).LatestCheckpoint(ctx, m.logID.String())
 	if err != nil {
 		return fmt.Errorf("fetching first checkpoint: %s", err)
 	}
@@ -245,7 +244,7 @@ func (m *mtca) InitLog(ctx context.Context) error {
 // Preflight gets the latest checkpoint from the database and reads the corresponding
 // frontier tiles from storage. It must be called on startup, before Loop().
 func (m *mtca) Preflight(ctx context.Context) error {
-	latest, err := m.latestCheckpoint(ctx)
+	latest, err := treedb.New(m.db).LatestCheckpoint(ctx, m.logID.String())
 	if err != nil {
 		return err
 	}
@@ -428,12 +427,12 @@ func (m *mtca) sequence(ctx context.Context) error {
 		return nil
 	}
 
-	latest, err := m.latestCheckpoint(ctx)
+	latest, err := treedb.New(m.db).LatestCheckpoint(ctx, m.logID.String())
 	if err != nil {
 		return err
 	}
 
-	if !latest.mirrored() {
+	if !latest.Mirrored() {
 		return fmt.Errorf("temporary: checkpoint ID %d (tree size %d): %w",
 			latest.ID, latest.TreeSize, ErrCheckpointNotReady)
 	}
@@ -483,7 +482,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 		return fmt.Errorf("staging candidate tiles: %s", err)
 	}
 
-	newCheckpoint := checkpoint{
+	newCheckpoint := &treedb.CheckpointModel{
 		ID:              0,
 		MTCLogID:        m.logID.String(),
 		MTCASignature:   nil,
@@ -493,7 +492,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 		RootHash:        newRootHash[:],
 	}
 
-	err = newCheckpoint.valid()
+	err = newCheckpoint.Valid()
 	if err != nil {
 		return fmt.Errorf("validating checkpoint: %s", err)
 	}
@@ -506,7 +505,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 	// the previous, signed, checkpoint, MTCA should try to re-sign the checkpoint and proceed from there.
 	//
 	// Note: Insert() updates the ID field of its parameter due to SetKeys(true, "ID")
-	err = m.db.Insert(ctx, &newCheckpoint)
+	err = m.db.Insert(ctx, newCheckpoint)
 	if err != nil {
 		return err
 	}
@@ -529,7 +528,7 @@ func (m *mtca) sequence(ctx context.Context) error {
 
 		// Note that we're doing HSM work while holding a database lock. That's intentional; the database lock
 		// is to prevent the possibility of a concurrent signer on the same tree.
-		caSig, err := m.signCheckpoint(&newCheckpoint)
+		caSig, err := m.signCheckpoint(newCheckpoint)
 		if err != nil {
 			return nil, err
 		}
@@ -591,81 +590,8 @@ func (m *mtca) sequence(ctx context.Context) error {
 	return nil
 }
 
-// checkpoint represents the database storage of a checkpoint and associated signatures.
-//
-// For signing, the TreeSize and RootHash fields are incorporated into a `cosigned.Message`.
-type checkpoint struct {
-	ID              int64   `db:"id"`
-	MTCLogID        string  `db:"mtcLogID"`
-	MTCASignature   []byte  `db:"mtcaSignature"`
-	MirrorID        *string `db:"mirrorID"`
-	MirrorSignature []byte  `db:"mirrorSignature"`
-	TreeSize        int64   `db:"treeSize"`
-	RootHash        []byte  `db:"rootHash"`
-}
-
-func (c *checkpoint) valid() error {
-	if len(c.MTCLogID) == 0 {
-		return errors.New("MTCLogID is empty")
-	}
-	if c.TreeSize == 0 {
-		return errors.New("TreeSize is 0")
-	}
-	if len(c.RootHash) == 0 {
-		return errors.New("RootHash is empty")
-	}
-	if len(c.RootHash) != sha256.Size {
-		return fmt.Errorf("RootHash is %d bytes", len(c.RootHash))
-	}
-
-	return nil
-}
-
-func (c *checkpoint) mirrored() bool {
-	return len(c.MTCASignature) > 0 && len(c.MirrorSignature) > 0
-}
-
-// String returns a string that is reasonable to print in logs, omitting the (large) signatures.
-func (c *checkpoint) String() string {
-	caSig := "empty"
-	if len(c.MTCASignature) > 0 {
-		caSig = "non-empty"
-	}
-	mirrorSig := "empty"
-	if len(c.MirrorSignature) > 0 {
-		mirrorSig = "non-empty"
-	}
-	var mirrorID string
-	if c.MirrorID != nil {
-		mirrorID = *c.MirrorID
-	}
-	return fmt.Sprintf("ID:%d MTCLogID:%s MTCASignature:%s MirrorID:%s MirrorSignature:%s TreeSize:%d RootHash:%x",
-		c.ID, c.MTCLogID, caSig, mirrorID, mirrorSig, c.TreeSize, c.RootHash)
-}
-
-func (m *mtca) latestCheckpoint(ctx context.Context) (*checkpoint, error) {
-	var latest checkpoint
-	err := m.db.SelectOne(ctx, &latest,
-		`SELECT id, checkpoints.mtcLogID, mtcaSignature, mirrorID,
-		        mirrorSignature, treeSize, rootHash
-		 FROM latestCheckpoint JOIN checkpoints
-		 USING(id)
-		 WHERE latestCheckpoint.mtcLogID = ? AND
-		       checkpoints.mtcLogID = ?`,
-		m.logID.String(),
-		m.logID.String())
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("getting latest checkpoint for %q: issuance log DB is not initialized", m.logID.String())
-		}
-		return nil, fmt.Errorf("getting latest checkpoint for %q: %w", m.logID.String(), err)
-	}
-
-	return &latest, nil
-}
-
-func (m *mtca) signCheckpoint(c *checkpoint) ([]byte, error) {
-	err := c.valid()
+func (m *mtca) signCheckpoint(c *treedb.CheckpointModel) ([]byte, error) {
+	err := c.Valid()
 	if err != nil {
 		return nil, fmt.Errorf("validating checkpoint: %s", err)
 	}

--- a/mtca/mtca_test.go
+++ b/mtca/mtca_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/letsencrypt/boulder/trees/entry"
 	"github.com/letsencrypt/boulder/trees/issuancelog"
 	"github.com/letsencrypt/boulder/trees/tiles"
+	"github.com/letsencrypt/boulder/trees/treedb"
 )
 
 // setup returns a working mtca, its fake tile storage, and a cleanup
@@ -154,35 +155,35 @@ func TestPool(t *testing.T) {
 func TestCheckpointValid(t *testing.T) {
 	type testCase struct {
 		name  string
-		value checkpoint
+		value treedb.CheckpointModel
 	}
 
 	rootHash := [32]byte{}
 
 	testCases := []testCase{
-		{"no MTCLogID", checkpoint{ID: 7, TreeSize: 9, RootHash: rootHash[:]}},
-		{"no TreeSize", checkpoint{ID: 7, MTCLogID: "TestLog", RootHash: rootHash[:]}},
-		{"short RootHash", checkpoint{ID: 7, MTCLogID: "TestLog", TreeSize: 9, RootHash: rootHash[:4]}},
-		{"no RootHash", checkpoint{ID: 7, MTCLogID: "TestLog", TreeSize: 9}},
+		{"no MTCLogID", treedb.CheckpointModel{ID: 7, TreeSize: 9, RootHash: rootHash[:]}},
+		{"no TreeSize", treedb.CheckpointModel{ID: 7, MTCLogID: "TestLog", RootHash: rootHash[:]}},
+		{"short RootHash", treedb.CheckpointModel{ID: 7, MTCLogID: "TestLog", TreeSize: 9, RootHash: rootHash[:4]}},
+		{"no RootHash", treedb.CheckpointModel{ID: 7, MTCLogID: "TestLog", TreeSize: 9}},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.value.valid()
+			err := tc.value.Valid()
 			if err == nil {
 				t.Errorf("checkpoint.valid(): got nil, want error")
 			}
 		})
 	}
 
-	goodCheckpoint := checkpoint{
+	goodCheckpoint := treedb.CheckpointModel{
 		ID:       7,
 		MTCLogID: "TestLog",
 		TreeSize: 9,
 		RootHash: rootHash[:],
 	}
 
-	err := goodCheckpoint.valid()
+	err := goodCheckpoint.Valid()
 	if err != nil {
 		t.Errorf("goodCheckpoint.valid(): got %q, want no error", err)
 	}
@@ -304,9 +305,9 @@ func mirrorCosign(t *testing.T, m *mtca) {
 //   - m.frontier
 //   - m.latestCheckpoint()
 //   - fake tile storage
-func verifyStores(t *testing.T, m *mtca, fs3 *bs3test.FakeS3) *checkpoint {
+func verifyStores(t *testing.T, m *mtca, fs3 *bs3test.FakeS3) *treedb.CheckpointModel {
 	t.Helper()
-	latest, err := m.latestCheckpoint(t.Context())
+	latest, err := treedb.New(m.db).LatestCheckpoint(t.Context(), m.logID.String())
 	if err != nil {
 		t.Fatalf("getting latest: %s", err)
 	}
@@ -486,8 +487,8 @@ func TestSequenceStorageFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("sequencing with failing storage: got nil error, want error")
 	}
-	if !strings.Contains(err.Error(), "staging") {
-		t.Errorf("sequencing with failing storage: got %q, want a staging error", err)
+	if !strings.Contains(err.Error(), "staging candidate tiles") {
+		t.Fatalf("sequencing with failing storage: got %q, want a 'staging candidate tiles' error", err)
 	}
 
 	// The waiting RPCs should get their responses.
@@ -531,7 +532,7 @@ func TestInitLog(t *testing.T) {
 		t.Errorf("second InitLog: got nil error, want error")
 	}
 
-	latest, err := mtca.latestCheckpoint(t.Context())
+	latest, err := treedb.New(mtca.db).LatestCheckpoint(t.Context(), mtca.logID.String())
 	if err != nil {
 		t.Fatalf("getting latest: %s", err)
 	}
@@ -547,7 +548,7 @@ func TestInitLog(t *testing.T) {
 	verifyCheckpoint(t, mtca, latest)
 }
 
-func verifyCheckpoint(t *testing.T, mtca *mtca, checkpoint *checkpoint) {
+func verifyCheckpoint(t *testing.T, mtca *mtca, checkpoint *treedb.CheckpointModel) {
 	t.Helper()
 	message := cosigned.Message{
 		CosignerName: "oid/1.3.6.1.4.1." + mtca.logID.CAID,

--- a/mtpublisher/mtpublisher.go
+++ b/mtpublisher/mtpublisher.go
@@ -7,10 +7,8 @@ import (
 	"crypto"
 	"crypto/mldsa"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/base64"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"time"
 
@@ -21,6 +19,7 @@ import (
 	"github.com/letsencrypt/boulder/trees/checkpoint"
 	"github.com/letsencrypt/boulder/trees/cosignature"
 	"github.com/letsencrypt/boulder/trees/issuancelog"
+	"github.com/letsencrypt/boulder/trees/treedb"
 )
 
 // publisher polls the MTC issuance log and cosigns the latest checkpoint if it
@@ -29,7 +28,7 @@ import (
 // as the publisher will once the mirror is a separate server. It is a stub for
 // the real MTPublisher.
 type publisher struct {
-	db             *db.WrappedMap
+	treedb         checkpointDB
 	interval       time.Duration
 	mtcLogID       string
 	origin         string
@@ -39,6 +38,11 @@ type publisher struct {
 	mirrorCosigner *cosignature.Cosigner
 	verifier       *cosignature.Verifier
 	log            blog.Logger
+}
+
+type checkpointDB interface {
+	LatestCheckpoint(ctx context.Context, mtcLogID string) (*treedb.CheckpointModel, error)
+	AddMirrorSignature(ctx context.Context, id int64, mirrorID string, mirrorSignature []byte, mtcLogID string) error
 }
 
 // New returns a publisher for the issuance log logID. It cosigns as the mirror
@@ -68,7 +72,7 @@ func New(dbMap *db.WrappedMap, interval time.Duration, logID issuancelog.ID, mir
 	mirrorKeyID := binary.BigEndian.Uint32(h.Sum(nil)[:4])
 
 	return &publisher{
-		db:             dbMap,
+		treedb:         treedb.New(dbMap),
 		interval:       interval,
 		mtcLogID:       logID.String(),
 		origin:         cosigner.Origin(),
@@ -79,16 +83,6 @@ func New(dbMap *db.WrappedMap, interval time.Duration, logID issuancelog.ID, mir
 		verifier:       verifier,
 		log:            log,
 	}, nil
-}
-
-type checkpointEntry struct {
-	ID              int64   `db:"id"`
-	MTCLogID        string  `db:"mtcLogID"`
-	MTCASignature   []byte  `db:"mtcaSignature"`
-	MirrorID        *string `db:"mirrorID"`
-	MirrorSignature []byte  `db:"mirrorSignature"`
-	TreeSize        int64   `db:"treeSize"`
-	RootHash        []byte  `db:"rootHash"`
 }
 
 // cosign cosigns the checkpoint described by tree as the mirror and returns the
@@ -111,22 +105,11 @@ func (p *publisher) cosign(tree tlog.Tree) (string, error) {
 // cosignature and stores the raw signature in the database. Start calls it at
 // each interval.
 func (p *publisher) Publish(ctx context.Context) error {
-	var latest checkpointEntry
-	err := p.db.SelectOne(ctx, &latest,
-		`SELECT id, checkpoints.mtcLogID, mtcaSignature, mirrorID,
-		        mirrorSignature, treeSize, rootHash
-		 FROM latestCheckpoint JOIN checkpoints
-		 USING(id)
-		 WHERE latestCheckpoint.mtcLogID = ? AND
-		       checkpoints.mtcLogID = ?`,
-		p.mtcLogID,
-		p.mtcLogID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil
-	}
+	latest, err := p.treedb.LatestCheckpoint(ctx, p.mtcLogID)
 	if err != nil {
-		return fmt.Errorf("selecting the latest checkpoint: %w", err)
+		return err
 	}
+
 	if latest.MirrorSignature != nil {
 		return nil
 	}
@@ -157,9 +140,8 @@ func (p *publisher) Publish(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("checkpoint %d cosignature: %w", latest.ID, err)
 	}
-	_, err = p.db.ExecContext(ctx,
-		"UPDATE checkpoints SET mirrorID = ?, mirrorSignature = ? WHERE id = ? AND mtcLogID = ?",
-		p.mirrorID, mirrorCosig, latest.ID, p.mtcLogID)
+
+	err = p.treedb.AddMirrorSignature(ctx, latest.ID, p.mirrorID, mirrorCosig, p.mtcLogID)
 	if err != nil {
 		return fmt.Errorf("storing checkpoint %d cosignature (%s size %d): %w", latest.ID, latest.MTCLogID, latest.TreeSize, err)
 	}

--- a/mtpublisher/mtpublisher_test.go
+++ b/mtpublisher/mtpublisher_test.go
@@ -3,22 +3,22 @@
 package mtpublisher
 
 import (
+	"bytes"
 	"context"
 	"crypto/mldsa"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"golang.org/x/mod/sumdb/tlog"
 
-	"github.com/letsencrypt/boulder/db"
 	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/privatekey"
-	"github.com/letsencrypt/boulder/sa"
-	"github.com/letsencrypt/boulder/test/vars"
 	"github.com/letsencrypt/boulder/trees/cosignature"
 	"github.com/letsencrypt/boulder/trees/issuancelog"
+	"github.com/letsencrypt/boulder/trees/treedb"
 )
 
 const (
@@ -28,70 +28,52 @@ const (
 
 var testLogID = issuancelog.ID{CAID: "44947.4.1", LogNumber: 44}
 
-func setupDB(t *testing.T) *db.WrappedMap {
-	t.Helper()
-
-	dbMap, err := sa.DBMapForTest(vars.DBConnMTCMeta_44947_4_1_0_44FullPerms)
-	if err != nil {
-		t.Fatalf("opening mtcmeta dbMap: %s", err)
-	}
-	truncate := func(ctx context.Context) error {
-		_, err := dbMap.ExecContext(ctx, "TRUNCATE TABLE checkpoints")
-		if err != nil {
-			return err
-		}
-		_, err = dbMap.ExecContext(ctx, "TRUNCATE TABLE latestCheckpoint")
-		return err
-	}
-	err = truncate(t.Context())
-	if err != nil {
-		t.Fatalf("truncating tables: %s", err)
-	}
-	t.Cleanup(func() {
-		err := truncate(context.Background())
-		if err != nil {
-			t.Logf("cleaning up tables: %s", err)
-		}
-	})
-	return dbMap
+type mockTreeDB struct {
+	latestCheckpoint *treedb.CheckpointModel
 }
 
-// setLatest points latestCheckpoint at the checkpoint with the given id, as the
-// sequencer does when it adopts a checkpoint.
-func setLatest(t *testing.T, dbMap *db.WrappedMap, logID string, id int64) {
-	t.Helper()
-	_, err := dbMap.ExecContext(t.Context(),
-		"REPLACE INTO latestCheckpoint (mtcLogID, id) VALUES (?, ?)", logID, id)
-	if err != nil {
-		t.Fatalf("pointing latestCheckpoint at %d: %s", id, err)
+func newMockDB(mtcLogID string) *mockTreeDB {
+	var rootHash [32]byte
+	return &mockTreeDB{
+		latestCheckpoint: &treedb.CheckpointModel{
+			ID:       1,
+			RootHash: rootHash[:],
+			TreeSize: 1,
+			MTCLogID: mtcLogID,
+		},
 	}
 }
 
-func insertCheckpoint(t *testing.T, dbMap *db.WrappedMap, logID string, treeSize int64) int64 {
-	t.Helper()
-
-	res, err := dbMap.ExecContext(t.Context(),
-		"INSERT INTO checkpoints (mtcLogID, mtcaSignature, treeSize, rootHash) VALUES (?, ?, ?, ?)",
-		logID, []byte("mtca-signature"), treeSize, make([]byte, 32))
-	if err != nil {
-		t.Fatalf("inserting checkpoint (%s size %d): %s", logID, treeSize, err)
-	}
-	id, err := res.LastInsertId()
-	if err != nil {
-		t.Fatalf("reading insert id: %s", err)
-	}
-	return id
+func (m *mockTreeDB) LatestCheckpoint(ctx context.Context, mtcLogID string) (*treedb.CheckpointModel, error) {
+	return m.latestCheckpoint, nil
 }
 
-func lacksCosignature(t *testing.T, dbMap *db.WrappedMap, id int64) bool {
-	t.Helper()
-	var count int64
-	err := dbMap.SelectOne(t.Context(), &count,
-		"SELECT COUNT(*) FROM checkpoints WHERE id = ? AND mirrorID IS NULL AND mirrorSignature IS NULL", id)
-	if err != nil {
-		t.Fatalf("querying checkpoint %d: %s", id, err)
+func (m *mockTreeDB) AddMirrorSignature(ctx context.Context, id int64, mirrorID string, mirrorSignature []byte, mtcLogID string) error {
+	if m.latestCheckpoint.ID != id {
+		return fmt.Errorf("test assumption error: tried to add mirror signature for the wrong ID")
 	}
-	return count == 1
+	if m.latestCheckpoint.MTCLogID != mtcLogID {
+		return fmt.Errorf("test assumption error: tried to add mirror signature for the wrong MTCLogID (%s vs %s)", m.latestCheckpoint.MTCLogID, mtcLogID)
+	}
+	m.latestCheckpoint.MirrorID = &mirrorID
+	m.latestCheckpoint.MirrorSignature = mirrorSignature
+	return nil
+}
+
+func insertCheckpoint(t *testing.T, mockDB *mockTreeDB, logID string, treeSize int64) {
+	t.Helper()
+
+	mockDB.latestCheckpoint = &treedb.CheckpointModel{
+		ID:            mockDB.latestCheckpoint.ID + 1,
+		MTCLogID:      logID,
+		MTCASignature: []byte("mtca-signature"),
+		TreeSize:      treeSize,
+		RootHash:      make([]byte, 32),
+	}
+}
+
+func lacksCosignature(mockDB *mockTreeDB) bool {
+	return mockDB.latestCheckpoint.MirrorID == nil && len(mockDB.latestCheckpoint.MirrorSignature) == 0
 }
 
 // testKey returns a deterministic ML-DSA-44 key so the test can verify the
@@ -147,12 +129,14 @@ func TestCosign(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
-	dbMap := setupDB(t)
 	key := testKey(t)
-	p, err := New(dbMap, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
+	p, err := New(nil, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
+
+	mockDB := newMockDB(mtcLogID)
+	p.treedb = mockDB
 
 	// A pass over an empty table is a no-op.
 	err = p.Publish(t.Context())
@@ -160,53 +144,26 @@ func TestPublish(t *testing.T) {
 		t.Fatalf("p.Publish() on an empty table: %s", err)
 	}
 
-	// An older checkpoint that is not cosigned, which must be left untouched.
-	olderCheckpointID := insertCheckpoint(t, dbMap, mtcLogID, 256)
-
 	// The latest checkpoint, which we expect to be cosigned by p.Publish().
-	latestCheckpointID := insertCheckpoint(t, dbMap, mtcLogID, 512)
-	setLatest(t, dbMap, mtcLogID, latestCheckpointID)
-
-	// A checkpoint for another log that was somehow inserted into this table,
-	// which must be left untouched thanks to the mtcLogID guard.
-	otherLogCheckpointID := insertCheckpoint(t, dbMap, "44947.4.2.0.99", 1024)
-
-	// A precommitted checkpoint the CA has not signed yet, which must be left
-	// untouched because latestCheckpoint does not reference it, even though its
-	// tree is the largest.
-	res, err := dbMap.ExecContext(t.Context(),
-		"INSERT INTO checkpoints (mtcLogID, treeSize, rootHash) VALUES (?, ?, ?)",
-		mtcLogID, int64(2048), make([]byte, 32))
-	if err != nil {
-		t.Fatalf("inserting precommitted checkpoint: %s", err)
-	}
-	precommitID, err := res.LastInsertId()
-	if err != nil {
-		t.Fatalf("reading insert id: %s", err)
-	}
+	insertCheckpoint(t, mockDB, mtcLogID, 512)
 
 	err = p.Publish(t.Context())
 	if err != nil {
 		t.Fatalf("p.Publish(): %s", err)
 	}
 
-	type row struct {
-		MirrorID  string `db:"mirrorID"`
-		MirrorSig []byte `db:"mirrorSignature"`
-	}
-	var cosigned row
-	err = dbMap.SelectOne(t.Context(), &cosigned, "SELECT mirrorID, mirrorSignature FROM checkpoints WHERE id = ?", latestCheckpointID)
+	cosigned, err := mockDB.LatestCheckpoint(context.Background(), mtcLogID)
 	if err != nil {
-		t.Fatalf("selecting the latest checkpoint: %s", err)
+		t.Fatal(err)
 	}
 
 	// Check that the latest checkpoint was cosigned, and the others were
 	// untouched.
-	if cosigned.MirrorID != mirrorID {
-		t.Errorf("mirrorID = %q, want %q", cosigned.MirrorID, mirrorID)
+	if cosigned.MirrorID == nil || *cosigned.MirrorID != mirrorID {
+		t.Errorf("mirrorID = %v, want %q", cosigned.MirrorID, mirrorID)
 	}
-	if len(cosigned.MirrorSig) != mldsa.MLDSA44SignatureSize {
-		t.Fatalf("latest checkpoint's mirrorSignature is %d bytes, want %d", len(cosigned.MirrorSig), mldsa.MLDSA44SignatureSize)
+	if len(cosigned.MirrorSignature) != mldsa.MLDSA44SignatureSize {
+		t.Fatalf("latest checkpoint's mirrorSignature is %d bytes, want %d", len(cosigned.MirrorSignature), mldsa.MLDSA44SignatureSize)
 	}
 
 	verifier, err := cosignature.NewVerifier(mirrorID, key.PublicKey())
@@ -214,26 +171,15 @@ func TestPublish(t *testing.T) {
 		t.Fatalf("NewVerifier: %s", err)
 	}
 	text := "oid/1.3.6.1.4.1." + mtcLogID + "\n512\n" + base64.StdEncoding.EncodeToString(make([]byte, 32)) + "\n"
-	timestampedSignature := append(make([]byte, 8), cosigned.MirrorSig...)
+	timestampedSignature := append(make([]byte, 8), cosigned.MirrorSignature...)
 	if !verifier.Verify([]byte(text), timestampedSignature) {
 		t.Error("stored mirror cosignature does not verify against the checkpoint text")
-	}
-	if !lacksCosignature(t, dbMap, olderCheckpointID) {
-		t.Error("older checkpoint was cosigned, only the latest should be")
-	}
-	if !lacksCosignature(t, dbMap, otherLogCheckpointID) {
-		t.Errorf("another log's checkpoint (id=%d) was cosigned, despite the mtcLogID guard", otherLogCheckpointID)
-	}
-	if !lacksCosignature(t, dbMap, precommitID) {
-		t.Error("precommitted checkpoint was cosigned before the CA signed it")
 	}
 }
 
 // TestPublishRejectsMismatchedKey checks that a cosignature that fails to
 // verify against the configured public key is not stored.
 func TestPublishRejectsMismatchedKey(t *testing.T) {
-	dbMap := setupDB(t)
-
 	otherSeed := make([]byte, 32)
 	for i := range otherSeed {
 		otherSeed[i] = byte(255 - i)
@@ -243,65 +189,52 @@ func TestPublishRejectsMismatchedKey(t *testing.T) {
 		t.Fatalf("NewPrivateKey: %s", err)
 	}
 
-	p, err := New(dbMap, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(testKey(t)), otherKey.PublicKey(), blog.NewMock())
+	p, err := New(nil, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(testKey(t)), otherKey.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
 
-	id := insertCheckpoint(t, dbMap, mtcLogID, 512)
-	setLatest(t, dbMap, mtcLogID, id)
+	mockDB := newMockDB(mtcLogID)
+	p.treedb = mockDB
+
+	insertCheckpoint(t, mockDB, mtcLogID, 512)
 
 	err = p.Publish(t.Context())
 	if err == nil {
 		t.Error("publish with a mismatched public key = nil error, want error")
 	}
-	if !lacksCosignature(t, dbMap, id) {
+	if !lacksCosignature(mockDB) {
 		t.Error("cosignature was stored despite failing verification")
 	}
 }
 
 func TestPublishWhenLatestAlreadySigned(t *testing.T) {
-	dbMap := setupDB(t)
 	key := testKey(t)
-	p, err := New(dbMap, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
+	p, err := New(nil, time.Second, testLogID, mirrorID, privatekey.NewDeterministicSigner(key), key.PublicKey(), blog.NewMock())
 	if err != nil {
 		t.Fatalf("New: %s", err)
 	}
 
+	mockDB := newMockDB(mtcLogID)
+	p.treedb = mockDB
+
 	// Insert a checkpoint that is already cosigned, which must be left
 	// untouched.
-	res, err := dbMap.ExecContext(t.Context(),
-		"INSERT INTO checkpoints (mtcLogID, mtcaSignature, treeSize, rootHash, mirrorID, mirrorSignature) VALUES (?, ?, ?, ?, ?, ?)",
-		mtcLogID, []byte("mtca-signature"), int64(512), make([]byte, 32), "existing.cosigner", []byte("already-signed-bruh"))
-	if err != nil {
-		t.Fatalf("inserting cosigned checkpoint: %s", err)
-	}
-	cosignedID, err := res.LastInsertId()
-	if err != nil {
-		t.Fatalf("reading insert id: %s", err)
-	}
-	setLatest(t, dbMap, mtcLogID, cosignedID)
-
-	// Insert an older (non-latest) checkpoint that is not cosigned, which must
-	// be left untouched.
-	olderID := insertCheckpoint(t, dbMap, mtcLogID, 256)
+	insertCheckpoint(t, mockDB, mtcLogID, 512)
+	existing := "existing.cosigner"
+	mockDB.latestCheckpoint.MirrorID = &existing
+	mockDB.latestCheckpoint.MirrorSignature = []byte("already-signed-bruh")
 
 	err = p.Publish(t.Context())
 	if err != nil {
 		t.Fatalf("p.Publish(): %s", err)
 	}
 
-	// The latest checkpoint is already cosigned, so the pass must leave both
-	// checkpoints untouched.
-	if !lacksCosignature(t, dbMap, olderID) {
-		t.Error("older checkpoint was cosigned, the pass should have stopped at the signed latest")
+	// The latest checkpoint was already cosigned, so the pass must leave it untouched.
+	if !bytes.Equal(mockDB.latestCheckpoint.MirrorSignature, []byte("already-signed-bruh")) {
+		t.Errorf("MirrorSignature: got %x, want %x", mockDB.latestCheckpoint.MirrorSignature, []byte("already-signed-bruh"))
 	}
-	var mirrorCosignature []byte
-	err = dbMap.SelectOne(t.Context(), &mirrorCosignature, "SELECT mirrorSignature FROM checkpoints WHERE mtcLogID = ? AND treeSize = 512", mtcLogID)
-	if err != nil {
-		t.Fatalf("selecting the cosigned checkpoint: %s", err)
-	}
-	if string(mirrorCosignature) != "already-signed-bruh" {
-		t.Errorf("existing cosignature was replaced: %q", mirrorCosignature)
+	if mockDB.latestCheckpoint.MirrorID == nil || *mockDB.latestCheckpoint.MirrorID != "existing.cosigner" {
+		t.Errorf("MirrorID: got %v, want %s", mockDB.latestCheckpoint.ID, "existing.cosigner")
 	}
 }

--- a/trees/treedb/treedb.go
+++ b/trees/treedb/treedb.go
@@ -1,0 +1,92 @@
+package treedb
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/letsencrypt/boulder/db"
+)
+
+var ErrIssuanceLogNotInitialized = errors.New("issuance log DB not initialized")
+
+// CheckpointModel represents the database storage of a checkpoint and associated signatures.
+//
+// For signing, the TreeSize and RootHash fields are incorporated into a `cosigned.Message`.
+type CheckpointModel struct {
+	ID              int64   `db:"id"`
+	MTCLogID        string  `db:"mtcLogID"`
+	MTCASignature   []byte  `db:"mtcaSignature"`
+	MirrorID        *string `db:"mirrorID"`
+	MirrorSignature []byte  `db:"mirrorSignature"`
+	TreeSize        int64   `db:"treeSize"`
+	RootHash        []byte  `db:"rootHash"`
+}
+
+func (c *CheckpointModel) Valid() error {
+	if len(c.MTCLogID) == 0 {
+		return errors.New("MTCLogID is empty")
+	}
+	if c.TreeSize == 0 {
+		return errors.New("TreeSize is 0")
+	}
+	if len(c.RootHash) == 0 {
+		return errors.New("RootHash is empty")
+	}
+	if len(c.RootHash) != sha256.Size {
+		return fmt.Errorf("RootHash is %d bytes", len(c.RootHash))
+	}
+
+	return nil
+}
+
+func (c *CheckpointModel) Mirrored() bool {
+	return len(c.MTCASignature) > 0 && len(c.MirrorSignature) > 0
+}
+
+type Impl struct {
+	db *db.WrappedMap
+}
+
+func (i *Impl) LatestCheckpoint(ctx context.Context, mtcLogID string) (*CheckpointModel, error) {
+	latest := new(CheckpointModel)
+	err := i.db.SelectOne(ctx, &latest,
+		`SELECT id, checkpoints.mtcLogID, mtcaSignature, mirrorID,
+		        mirrorSignature, treeSize, rootHash
+		 FROM latestCheckpoint JOIN checkpoints
+		 USING(id)
+		 WHERE latestCheckpoint.mtcLogID = ? AND
+		       checkpoints.mtcLogID = ?`,
+		mtcLogID,
+		mtcLogID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("getting latest checkpoint for %q: %w", mtcLogID, ErrIssuanceLogNotInitialized)
+		}
+		return nil, fmt.Errorf("getting latest checkpoint for %q: %w", mtcLogID, err)
+	}
+	return latest, nil
+}
+
+func (i *Impl) AddMirrorSignature(ctx context.Context, id int64, mirrorID string, mirrorCosig []byte, mtcLogID string) error {
+	r, err := i.db.ExecContext(ctx,
+		"UPDATE checkpoints SET mirrorID = ?, mirrorSignature = ? WHERE id = ? AND mtcLogID = ?",
+		mirrorID, mirrorCosig, id, mtcLogID)
+	if err != nil {
+		return err
+	}
+	n, err := r.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("getting RowsAffected: %s", err)
+	}
+	if n != 1 {
+		return fmt.Errorf("adding mirror signature: %d rows affected (want 1 row affected)", n)
+	}
+	return nil
+}
+
+func New(db *db.WrappedMap) *Impl {
+	return &Impl{db}
+}


### PR DESCRIPTION
This allows mtca and mtpublisher to abstract their DB storage and mock it in tests. That in turn, removes a test flake when the mtca and mtpublisher unittests run in parallel.

Note that only mtpublisher_test.go currently has its storage fully mocked. In mtca there is a more complicated interaction with the database where we hold a lock while signing. We may be able to mock this too but it will be more complicated, and we'd like to fix the test flake quickly.

Note that this involved removing a number of test lines in mtpublisher_test.go that checked that cosigning operations only touched the lines they were intended to touch. I believe these have been adequately replaced by `mockTreeDB.AddMirrorSignature`'s check that it is only called with a target checkpoint ID equal to the latest checkpoint. But I would appreciate eyes on that in case there are tests that I need to port.

Fixes #8967 