### PR TITLE
grpc: clean up old user-agent context key.

### DIFF
--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -27,7 +27,6 @@ const (
 	clientRequestTimeKey   = "client-request-time"
 	// We use the "-bin" suffix to tell grpc's metadata package not to require the user-agent
 	// be printable ASCII. It's rare, but ACME clients can send non-ASCII user-agents.
-	// Remove `userAgentKey` once this has been deployed.
 	userAgentKey = "acme-client-user-agent-bin"
 )
 

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -25,11 +25,10 @@ const (
 	returnOverhead         = 20 * time.Millisecond
 	meaningfulWorkOverhead = 100 * time.Millisecond
 	clientRequestTimeKey   = "client-request-time"
-	userAgentKey           = "acme-client-user-agent"
 	// We use the "-bin" suffix to tell grpc's metadata package not to require the user-agent
 	// be printable ASCII. It's rare, but ACME clients can send non-ASCII user-agents.
 	// Remove `userAgentKey` once this has been deployed.
-	userAgentKey2 = "acme-client-user-agent-bin"
+	userAgentKey = "acme-client-user-agent-bin"
 )
 
 type serverInterceptor interface {
@@ -95,9 +94,7 @@ func (smi *serverMetadataInterceptor) Unary(
 				return nil, err
 			}
 		}
-		if len(md[userAgentKey2]) > 0 {
-			ctx = web.WithUserAgent(ctx, md[userAgentKey2][0])
-		} else if len(md[userAgentKey]) > 0 {
+		if len(md[userAgentKey]) > 0 {
 			ctx = web.WithUserAgent(ctx, md[userAgentKey][0])
 		}
 	}
@@ -282,7 +279,6 @@ func (cmi *clientMetadataInterceptor) Unary(
 	reqMD := metadata.New(map[string]string{
 		clientRequestTimeKey: nowTS,
 		userAgentKey:         web.UserAgent(ctx),
-		userAgentKey2:        web.UserAgent(ctx),
 	})
 	// Configure the localCtx with the metadata so it gets sent along in the request
 	localCtx = metadata.NewOutgoingContext(localCtx, reqMD)
@@ -391,7 +387,6 @@ func (cmi *clientMetadataInterceptor) Stream(
 	reqMD := metadata.New(map[string]string{
 		clientRequestTimeKey: nowTS,
 		userAgentKey:         web.UserAgent(ctx),
-		userAgentKey2:        web.UserAgent(ctx),
 	})
 	// Configure the localCtx with the metadata so it gets sent along in the request
 	localCtx = metadata.NewOutgoingContext(localCtx, reqMD)


### PR DESCRIPTION
This follows-up on @mkhandker19's original PR #8930. Thank you for the contribution.