### PR TITLE
Add a new ct_log_horizon metric

### DIFF
--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -33,6 +33,7 @@ type CTPolicy struct {
 	log              blog.Logger
 	winnerCounter    *prometheus.CounterVec
 	shardExpiryGauge *prometheus.GaugeVec
+	horizonGauge     prometheus.Gauge
 }
 
 // New creates a new CTPolicy struct
@@ -56,6 +57,15 @@ func New(pub pubpb.PublisherClient, sctLogs loglist.List, infoLogs loglist.List,
 		}
 	}
 
+	horizonGauge := promauto.With(stats).NewGauge(prometheus.GaugeOpts{
+		Name: "ct_log_horizon",
+		Help: "Earliest certificate expiry, as Unix time, for which the configured SCT logs cannot satisfy the CT policy.",
+	})
+
+	h := horizon(sctLogs, time.Now())
+	horizonGauge.Set(float64(h.Unix()))
+	log.Infof("CT log horizon: %s", h.Format(time.RFC3339))
+
 	// Stagger must be positive for time.Ticker.
 	// Default to the relatively safe value of 1 second.
 	if stagger <= 0 {
@@ -71,6 +81,7 @@ func New(pub pubpb.PublisherClient, sctLogs loglist.List, infoLogs loglist.List,
 		log:              log,
 		winnerCounter:    winnerCounter,
 		shardExpiryGauge: shardExpiryGauge,
+		horizonGauge:     horizonGauge,
 	}
 }
 

--- a/ctpolicy/horizon.go
+++ b/ctpolicy/horizon.go
@@ -27,7 +27,7 @@ func satisfiable(logs loglist.List) bool {
 func horizon(logs loglist.List, now time.Time) time.Time {
 	candidates := []time.Time{now}
 	for _, log := range logs {
-    // We only have to check the boundaries of log boundaries
+		// We only have to check the boundaries of log boundaries
 		for _, t := range []time.Time{log.StartInclusive, log.EndExclusive} {
 			if !t.IsZero() && t.After(now) {
 				candidates = append(candidates, t)

--- a/ctpolicy/horizon.go
+++ b/ctpolicy/horizon.go
@@ -1,0 +1,45 @@
+package ctpolicy
+
+import (
+	"slices"
+	"time"
+
+	"github.com/letsencrypt/boulder/ctpolicy/loglist"
+)
+
+// horizonNever is returned when there is no horizon.
+// This is only possible when non-sharded logs alone suffice.
+// In practice this won't happen.
+var horizonNever = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// satisfiable returns true if the given logs can produce a set of SCTs which
+// satisfies the CT policy. It is pretending every log returned an SCT.
+func satisfiable(logs loglist.List) bool {
+	results := make([]result, len(logs))
+	for i, log := range logs {
+		results[i] = result{log: log}
+	}
+	return compliantSet(results) != nil
+}
+
+// horizon returns the earliest certificate expiry time, no earlier than now,
+// for which the given logs cannot satisfy the CT policy.
+func horizon(logs loglist.List, now time.Time) time.Time {
+	candidates := []time.Time{now}
+	for _, log := range logs {
+    // We only have to check the boundaries of log boundaries
+		for _, t := range []time.Time{log.StartInclusive, log.EndExclusive} {
+			if !t.IsZero() && t.After(now) {
+				candidates = append(candidates, t)
+			}
+		}
+	}
+	slices.SortFunc(candidates, time.Time.Compare)
+
+	for _, t := range candidates {
+		if !satisfiable(logs.ForTime(t)) {
+			return t
+		}
+	}
+	return horizonNever
+}

--- a/ctpolicy/horizon.go
+++ b/ctpolicy/horizon.go
@@ -27,19 +27,21 @@ func satisfiable(logs loglist.List) bool {
 func horizon(logs loglist.List, now time.Time) time.Time {
 	candidates := []time.Time{now}
 	for _, log := range logs {
-		// We only have to check the boundaries of log boundaries
-		for _, t := range []time.Time{log.StartInclusive, log.EndExclusive} {
-			if !t.IsZero() && t.After(now) {
-				candidates = append(candidates, t)
-			}
+		// We only have to check the points in time when a log's interval ends.
+		// Since log ends are exclusive, that's the moment where the horizon will be.
+		if log.EndExclusive.After(now) {
+			candidates = append(candidates, log.EndExclusive)
 		}
 	}
 	slices.SortFunc(candidates, time.Time.Compare)
 
+	// Find the first candidate time that isn't satisfiable.
 	for _, t := range candidates {
 		if !satisfiable(logs.ForTime(t)) {
 			return t
 		}
 	}
+
+	// If all log ends are satisfiable, there's never a horizon
 	return horizonNever
 }

--- a/ctpolicy/horizon_test.go
+++ b/ctpolicy/horizon_test.go
@@ -1,0 +1,194 @@
+package ctpolicy
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/letsencrypt/boulder/ctpolicy/loglist"
+	blog "github.com/letsencrypt/boulder/log"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/test"
+)
+
+func TestSatisfiable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		logs loglist.List
+		want bool
+	}{
+		{
+			name: "no logs",
+			logs: nil,
+			want: false,
+		},
+		{
+			name: "one operator",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false},
+				{Operator: "A", Tiled: false},
+			},
+			want: false,
+		},
+		{
+			name: "all tiled",
+			logs: loglist.List{
+				{Operator: "A", Tiled: true},
+				{Operator: "B", Tiled: true},
+			},
+			want: false,
+		},
+		{
+			name: "one non-tiled, one tiled",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false},
+				{Operator: "B", Tiled: true},
+			},
+			want: true,
+		},
+		{
+			name: "non-tiled log alongside another operator's tiled logs",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false},
+				{Operator: "A", Tiled: true},
+				{Operator: "B", Tiled: true},
+			},
+			want: true,
+		},
+		{
+			name: "two non-tiled operators",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false},
+				{Operator: "B", Tiled: false},
+			},
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := satisfiable(tc.logs)
+			if got != tc.want {
+				t.Errorf("satisfiable(%v) = %t, want %t", tc.logs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHorizon(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	day := func(d int) time.Time { return now.AddDate(0, 0, d) }
+
+	for _, tc := range []struct {
+		name string
+		logs loglist.List
+		want time.Time
+	}{
+		{
+			name: "no logs",
+			logs: nil,
+			want: now,
+		},
+		{
+			name: "non-sharded logs suffice forever",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false},
+				{Operator: "B", Tiled: true},
+			},
+			want: horizonNever,
+		},
+		{
+			name: "horizon is the end of the earliest critical shard",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false, StartInclusive: day(-10), EndExclusive: day(30)},
+				{Operator: "B", Tiled: true, StartInclusive: day(-10), EndExclusive: day(60)},
+			},
+			want: day(30),
+		},
+		{
+			name: "successor shard extends the horizon",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false, StartInclusive: day(-10), EndExclusive: day(30)},
+				{Operator: "A", Tiled: false, StartInclusive: day(30), EndExclusive: day(90)},
+				{Operator: "B", Tiled: true, StartInclusive: day(-10), EndExclusive: day(60)},
+			},
+			want: day(60),
+		},
+		{
+			name: "gap between shards is the horizon",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false, StartInclusive: day(-10), EndExclusive: day(30)},
+				{Operator: "A", Tiled: false, StartInclusive: day(31), EndExclusive: day(90)},
+				{Operator: "B", Tiled: true},
+			},
+			want: day(30),
+		},
+		{
+			name: "coverage which only begins later does not help before it starts",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false, StartInclusive: day(10), EndExclusive: day(90)},
+				{Operator: "B", Tiled: true},
+			},
+			want: now,
+		},
+		{
+			name: "shards which already ended are ignored",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false, StartInclusive: day(-90), EndExclusive: day(-10)},
+				{Operator: "A", Tiled: false, StartInclusive: day(-10), EndExclusive: day(90)},
+				{Operator: "B", Tiled: true},
+			},
+			want: day(90),
+		},
+		{
+			name: "losing the last non-tiled log is the horizon",
+			logs: loglist.List{
+				{Operator: "A", Tiled: false, StartInclusive: day(-10), EndExclusive: day(30)},
+				{Operator: "A", Tiled: true, StartInclusive: day(-10), EndExclusive: day(90)},
+				{Operator: "B", Tiled: true, StartInclusive: day(-10), EndExclusive: day(90)},
+			},
+			want: day(30),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := horizon(tc.logs, now)
+			if !got.Equal(tc.want) {
+				t.Errorf("horizon(...) = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHorizonMetrics(t *testing.T) {
+	// Inside a synctest bubble, time.Now() is deterministic, so New computes
+	// the horizon from a known instant.
+	synctest.Test(t, func(t *testing.T) {
+		mockLog := blog.NewMock()
+		defer mockLog.Close()
+		now := time.Now()
+		nextMonth := now.AddDate(0, 1, 0)
+		nextYear := now.AddDate(1, 0, 0)
+
+		ctp := New(&mockPub{}, loglist.List{
+			{Name: "LogA1", Operator: "OperA", Tiled: false, EndExclusive: nextMonth},
+			{Name: "LogA2", Operator: "OperA", Tiled: false, EndExclusive: nextYear},
+			{Name: "LogB1", Operator: "OperB", Tiled: true, EndExclusive: nextYear},
+		}, nil, nil, 0, mockLog, metrics.NoopRegisterer)
+		test.AssertMetricWithLabelsEquals(t, ctp.horizonGauge, prometheus.Labels{}, float64(nextYear.Unix()))
+
+		// Non-sharded logs which satisfy the policy have no horizon.
+		ctp = New(&mockPub{}, loglist.List{
+			{Name: "LogA1", Operator: "OperA", Tiled: false},
+			{Name: "LogB1", Operator: "OperB", Tiled: true},
+		}, nil, nil, 0, mockLog, metrics.NoopRegisterer)
+		test.AssertMetricWithLabelsEquals(t, ctp.horizonGauge, prometheus.Labels{}, float64(horizonNever.Unix()))
+
+		// A single operator can never satisfy the policy, so the horizon is
+		// the moment of startup.
+		ctp = New(&mockPub{}, loglist.List{
+			{Name: "LogA1", Operator: "OperA", Tiled: false},
+			{Name: "LogA2", Operator: "OperA", Tiled: true},
+		}, nil, nil, 0, mockLog, metrics.NoopRegisterer)
+		test.AssertMetricWithLabelsEquals(t, ctp.horizonGauge, prometheus.Labels{}, float64(now.Unix()))
+	})
+}


### PR DESCRIPTION
This adds a new metric, ct_log_horizon. That metric is the date at which we'll run out of enough CT logs to submit to.

I described this feature to Fable, which implemented most of this. In particular, it wrote more extensive tests than I probably would have, and I haven't touched them.  The comments outside of tests were written by me.

This will allow operators of Boulder to write an alert that the horizon is approaching and they need to update the CT log lists.