### PR TITLE
MTCProof: use 24-bit length for signatures

### DIFF
--- a/trees/proof/proof.go
+++ b/trees/proof/proof.go
@@ -46,7 +46,7 @@ func SigAlgEncoded() []byte {
 //	    uint48 start;
 //	    uint48 end;
 //	    HashValue inclusion_proof<0..2^16-1>;
-//	    SubtreeSignature signatures<0..2^16-1>;
+//	    SubtreeSignature signatures<0..2^24-1>;
 //	} MTCProof;
 type MTCProof struct {
 	Extensions     []byte
@@ -108,7 +108,7 @@ func (m *MTCProof) Marshal() ([]byte, error) {
 		sigBytes = append(sigBytes, sigByte)
 	}
 
-	builder.AddUint16LengthPrefixed(func(builder *cryptobyte.Builder) {
+	builder.AddUint24LengthPrefixed(func(builder *cryptobyte.Builder) {
 		for _, sb := range sigBytes {
 			builder.AddBytes(sb)
 		}
@@ -156,7 +156,7 @@ func UnmarshalMTCProof(in []byte) (*MTCProof, error) {
 	}
 
 	var signaturesBytes cryptobyte.String
-	if !input.ReadUint16LengthPrefixed(&signaturesBytes) {
+	if !input.ReadUint24LengthPrefixed(&signaturesBytes) {
 		return nil, fmt.Errorf("malformed signature bytes")
 	}
 

--- a/trees/proof/proof_test.go
+++ b/trees/proof/proof_test.go
@@ -93,7 +93,7 @@ func TestMTCProofMarshal(t *testing.T) {
 		"0040",         // inclusion_proof length: two 32-byte hashes
 		hex.EncodeToString(hash1[:]),
 		hex.EncodeToString(hash2[:]),
-		"000b",         // signatures length
+		"00000b",       // signatures length
 		"01aa0002bbcc", // signature 1
 		"0201020000",   // signature 2
 	}, ""))
@@ -117,7 +117,7 @@ func TestMTCProofSignatureOrdering(t *testing.T) {
 
 	expected, err := hex.DecodeString(
 		"0000" + "000000000000" + "000000000000" + "0000" +
-			"0011" + // combined byte length of the encoded signatures
+			"000011" + // combined byte length of the encoded signatures
 			"01aa000101" + // a: 1-byte ID sorts before all 2-byte IDs
 			"020102000102" + // b: same length as c, lexicographically first
 			"020103000103") // c
@@ -306,7 +306,7 @@ func TestUnmarshalMTCProofMalformed(t *testing.T) {
 	// Two cosignerIDs in the correct order, with shortest first: 0x02 comes before
 	// 0x01 0x02 because it's shorter. A naive comparison would put them the other way, so
 	// test that this parses.
-	input, err := hex.DecodeString(prefix + "0000" + "0009" + "01020000" + "0201020000")
+	input, err := hex.DecodeString(prefix + "0000" + "000009" + "01020000" + "0201020000")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
To match a recent spec update that will be in draft -06.

https://github.com/ietf-plants-wg/merkle-tree-certs/pull/314