### PR TITLE
Differentiate errors when the DNS resolver is unreachable versus a DNS error during validation

### DIFF
--- a/bdns/problem.go
+++ b/bdns/problem.go
@@ -162,6 +162,28 @@ func (d Error) Error() string {
 	return result
 }
 
+// ResolverUnreachable returns true if this error represents a failure to
+// communicate with the resolver at all: a network timeout, a connection
+// refused, a DNS-over-HTTPS transport failure, etc. It returns false when the
+// resolver did respond, even if that response was an error (e.g. SERVFAIL or
+// NXDOMAIN) or was truncated. It also returns false when the failure was
+// caused by the caller's context being canceled or exceeding its deadline,
+// since those don't necessarily indicate a problem with the resolver.
+//
+// Callers can use this to distinguish problems with the CA's own
+// infrastructure from problems with the subscriber's DNS.
+func (d Error) ResolverUnreachable() bool {
+	if d.underlying == nil {
+		return false
+	}
+	if errors.Is(d.underlying, context.Canceled) || errors.Is(d.underlying, context.DeadlineExceeded) {
+		return false
+	}
+	_, isNetErr := errors.AsType[*net.OpError](d.underlying)
+	_, isURLErr := errors.AsType[*url.Error](d.underlying)
+	return isNetErr || isURLErr
+}
+
 const detailDNSTimeout = "query timed out"
 const detailCanceled = "query timed out (and was canceled)"
 const detailDNSNetFailure = "networking error"

--- a/bdns/problem_test.go
+++ b/bdns/problem_test.go
@@ -65,6 +65,80 @@ func TestError(t *testing.T) {
 	}
 }
 
+func TestResolverUnreachable(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      Error
+		expected bool
+	}{
+		{
+			name:     "net error",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: &net.OpError{Err: errors.New("connection refused")}},
+			expected: true,
+		},
+		{
+			name:     "net timeout",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: &net.OpError{Err: dohTimeoutError{}}},
+			expected: true,
+		},
+		{
+			name:     "url error",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: &url.Error{Op: "POST", URL: "https://example.com/", Err: errors.New("connection refused")}},
+			expected: true,
+		},
+		{
+			name:     "url timeout",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: &url.Error{Op: "POST", URL: "https://example.com/", Err: dohTimeoutError{}}},
+			expected: true,
+		},
+		{
+			name:     "url error wrapping context deadline",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: &url.Error{Op: "POST", URL: "https://example.com/", Err: context.DeadlineExceeded}},
+			expected: false,
+		},
+		{
+			name:     "context deadline",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: context.DeadlineExceeded},
+			expected: false,
+		},
+		{
+			name:     "context canceled",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: context.Canceled},
+			expected: false,
+		},
+		{
+			name:     "other underlying error",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", underlying: errors.New("doh: http status 500")},
+			expected: false,
+		},
+		{
+			name:     "servfail",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", rCode: dns.RcodeServerFailure},
+			expected: false,
+		},
+		{
+			name:     "nxdomain",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", rCode: dns.RcodeNameError},
+			expected: false,
+		},
+		{
+			name:     "servfail with extended error",
+			err:      Error{recordType: dns.TypeA, hostname: "hostname", rCode: dns.RcodeServerFailure, extended: &dns.EDNS0_EDE{InfoCode: 6}},
+			expected: false,
+		},
+		{
+			name:     "truncated",
+			err:      Error{recordType: dns.TypeCAA, hostname: "hostname", truncated: true},
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			test.AssertEquals(t, tc.err.ResolverUnreachable(), tc.expected)
+		})
+	}
+}
+
 type dohTimeoutError struct{}
 
 func (dohTimeoutError) Error() string {

--- a/va/caa.go
+++ b/va/caa.go
@@ -151,7 +151,7 @@ func (va *ValidationAuthorityImpl) checkCAA(
 
 	foundAt, valid, response, err := va.checkCAARecords(ctx, ident, params)
 	if err != nil {
-		return berrors.DNSError("%s", err)
+		return dnsError(err, "%s", err)
 	}
 
 	va.log.AuditInfo("Checked CAA records", map[string]any{

--- a/va/caa_test.go
+++ b/va/caa_test.go
@@ -1112,6 +1112,17 @@ func TestMultiCAARechecking(t *testing.T) {
 	}
 }
 
+func TestCAAResolverUnreachable(t *testing.T) {
+	va, _ := setup(nil, "", nil, unreachableDNSClient(t))
+
+	err := va.checkCAA(ctx, identifier.NewDNS("localhost"), &caaParams{1, core.ChallengeTypeHTTP01})
+	test.AssertError(t, err, "expected CAA check to fail")
+	test.AssertErrorIs(t, err, berrors.InternalServer)
+	prob := detailedError(err)
+	test.AssertEquals(t, prob.Type, probs.ServerInternalProblem)
+	test.AssertContains(t, prob.Detail, "DNS problem: networking error looking up CAA")
+}
+
 func TestCAAFailure(t *testing.T) {
 	hs := httpSrv(t, expectedToken, false)
 	defer hs.Close()

--- a/va/dns.go
+++ b/va/dns.go
@@ -21,10 +21,25 @@ import (
 	"github.com/letsencrypt/boulder/identifier"
 )
 
+// dnsError converts an error returned by a bdns lookup into a BoulderError
+// whose detail is formatted like fmt.Sprintf(format, args...). Ordinarily the
+// result is a berrors.DNS error. But if the lookup failed because we couldn't
+// reach our own resolver at all, the result is a berrors.InternalServer error:
+// that's a problem with our infrastructure, not with the subscriber's DNS, and
+// it shouldn't be reported (or counted in metrics) as though it were.
+func dnsError(err error, format string, args ...any) error {
+	bdnsErr, ok := errors.AsType[bdns.Error](err)
+	if ok && bdnsErr.ResolverUnreachable() {
+		return berrors.InternalServerError(format, args...)
+	}
+	return berrors.DNSError(format, args...)
+}
+
 // getAddr queries for all A/AAAA records associated with hostname, and returns
 // all valid addresses resolved and the addresses of all resolvers used. If
 // there is an error resolving the hostname, or if no usable IP addresses are
-// available then a berrors.DNSError instance is returned with a nil netip.Addr
+// available then a berrors.DNS error (or, if we couldn't reach our resolver at
+// all, a berrors.InternalServer error) is returned with a nil netip.Addr
 // slice.
 func (va *ValidationAuthorityImpl) getAddrs(ctx context.Context, hostname string) ([]netip.Addr, []string, error) {
 	// Kick off both the A and AAAA lookups in parallel.
@@ -80,7 +95,7 @@ func (va *ValidationAuthorityImpl) getAddrs(ctx context.Context, hostname string
 	}
 
 	if errA != nil && errAAAA != nil {
-		return nil, nil, berrors.DNSError("%s; %s", errA, errAAAA)
+		return nil, nil, dnsError(errors.Join(errA, errAAAA), "%s; %s", errA, errAAAA)
 	}
 
 	addrs := append(addrsAAAA, addrsA...)
@@ -161,7 +176,7 @@ func (va *ValidationAuthorityImpl) validateDNS(ctx context.Context, ident identi
 	// Look for the required record in the DNS
 	txts, resolver, err := va.dnsClient.LookupTXT(ctx, challengeSubdomain)
 	if err != nil {
-		return nil, berrors.DNSError("%s", err)
+		return nil, dnsError(err, "%s", err)
 	}
 
 	// If there weren't any TXT records return a distinct error message to allow

--- a/va/dns_persist.go
+++ b/va/dns_persist.go
@@ -160,7 +160,7 @@ func (va *ValidationAuthorityImpl) validateDNSPersist01(ctx context.Context, ide
 	challengeSubdomain := fmt.Sprintf("%s.%s", core.DNSPersistPrefix, ident.Value)
 	txts, resolver, err := va.dnsClient.LookupTXT(ctx, challengeSubdomain)
 	if err != nil {
-		return nil, berrors.DNSError("Retrieving TXT records for DNS-PERSIST-01 challenge: %s", err)
+		return nil, dnsError(err, "Retrieving TXT records for DNS-PERSIST-01 challenge: %s", err)
 	}
 	if len(txts.Final) == 0 {
 		return nil, berrors.UnauthorizedError("No TXT record found for DNS-PERSIST-01 challenge")

--- a/va/dns_persist_test.go
+++ b/va/dns_persist_test.go
@@ -447,6 +447,17 @@ func (d *dnsPersistMultiStringDNS) LookupTXT(_ context.Context, _ string) (*bdns
 	return &bdns.Result[*dns.TXT]{Final: []*dns.TXT{rr}}, "dnsPersistMultiStringDNS", nil
 }
 
+func TestDNSPersist01ResolverUnreachable(t *testing.T) {
+	va, _ := setup(nil, "", nil, unreachableDNSClient(t))
+
+	_, err := va.validateDNSPersist01(context.Background(), identifier.NewDNS("localhost"), accountURIPrefixes[0]+"1", false)
+	test.AssertError(t, err, "expected validation to fail")
+	test.AssertErrorIs(t, err, berrors.InternalServer)
+	prob := detailedError(err)
+	test.AssertEquals(t, prob.Type, probs.ServerInternalProblem)
+	test.AssertContains(t, prob.Detail, "Retrieving TXT records for DNS-PERSIST-01 challenge: DNS problem: networking error looking up TXT")
+}
+
 func TestDNSPersist01MultiStringTXTRecord(t *testing.T) {
 	t.Parallel()
 

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -3,6 +3,7 @@ package va
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
 	"testing"
 	"time"
@@ -11,7 +12,9 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/letsencrypt/boulder/bdns"
+	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/identifier"
+	blog "github.com/letsencrypt/boulder/log"
 	"github.com/letsencrypt/boulder/metrics"
 	"github.com/letsencrypt/boulder/probs"
 	"github.com/letsencrypt/boulder/test"
@@ -191,6 +194,57 @@ func TestDNS01ValidationNoServer(t *testing.T) {
 	_, err = va.validateDNS01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization)
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.DNSProblem)
+}
+
+// unreachableDNSClient returns a real bdns.Client configured to talk to a DoH
+// resolver on a localhost port that nothing is listening on, so that every
+// lookup fails with a transport-level error rather than a DNS response.
+func unreachableDNSClient(t *testing.T) bdns.Client {
+	t.Helper()
+
+	// Grab a port that nothing is listening on by listening and then
+	// immediately closing. There's a small window in which something else
+	// could claim the port, but that's vanishingly unlikely in tests.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	test.AssertNotError(t, err, "Couldn't listen on localhost")
+	addr := l.Addr().String()
+	l.Close()
+
+	staticProvider, err := bdns.NewStaticProvider([]string{addr})
+	test.AssertNotError(t, err, "Couldn't make new static provider")
+
+	return bdns.New(
+		time.Second,
+		staticProvider,
+		metrics.NoopRegisterer,
+		clock.New(),
+		1,
+		"",
+		blog.NewMock(),
+		nil)
+}
+
+func TestDNS01ValidationResolverUnreachable(t *testing.T) {
+	va, _ := setup(nil, "", nil, unreachableDNSClient(t))
+
+	_, err := va.validateDNS01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization)
+	test.AssertError(t, err, "expected validation to fail")
+	test.AssertErrorIs(t, err, berrors.InternalServer)
+	prob := detailedError(err)
+	test.AssertEquals(t, prob.Type, probs.ServerInternalProblem)
+	test.AssertContains(t, prob.Detail, "DNS problem: networking error looking up TXT")
+}
+
+func TestGetAddrsResolverUnreachable(t *testing.T) {
+	va, _ := setup(nil, "", nil, unreachableDNSClient(t))
+
+	_, _, err := va.getAddrs(ctx, "localhost")
+	test.AssertError(t, err, "expected lookup to fail")
+	test.AssertErrorIs(t, err, berrors.InternalServer)
+	prob := detailedError(err)
+	test.AssertEquals(t, prob.Type, probs.ServerInternalProblem)
+	test.AssertContains(t, prob.Detail, "DNS problem: networking error looking up A")
+	test.AssertContains(t, prob.Detail, "DNS problem: networking error looking up AAAA")
 }
 
 func TestDNS01ValidationOK(t *testing.T) {

--- a/va/va.go
+++ b/va/va.go
@@ -456,6 +456,9 @@ func detailedError(err error) *probs.ProblemDetails {
 	if errors.Is(err, berrors.CAA) {
 		return probs.CAA(err.Error())
 	}
+	if errors.Is(err, berrors.InternalServer) {
+		return probs.ServerInternal(err.Error())
+	}
 
 	if h2SettingsFrameErrRegex.MatchString(err.Error()) {
 		return probs.Connection("Server is speaking HTTP/2 over HTTP")

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/letsencrypt/boulder/bdns"
 	"github.com/letsencrypt/boulder/core"
 	corepb "github.com/letsencrypt/boulder/core/proto"
+	berrors "github.com/letsencrypt/boulder/errors"
 	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/iana"
 	"github.com/letsencrypt/boulder/identifier"
@@ -911,5 +912,19 @@ func TestDetailedError(t *testing.T) {
 		if actual != tc.expected {
 			t.Errorf("Wrong detail for %v. Got %q, expected %q", tc.err, actual, tc.expected)
 		}
+	}
+
+	typeCases := []struct {
+		err      error
+		expected probs.ProblemType
+	}{
+		{berrors.DNSError("DNS problem: SERVFAIL looking up A for example.com"), probs.DNSProblem},
+		{berrors.InternalServerError("DNS problem: networking error looking up A for example.com"), probs.ServerInternalProblem},
+		{berrors.ConnectionFailureError("oops"), probs.ConnectionProblem},
+	}
+	for _, tc := range typeCases {
+		prob := detailedError(tc.err)
+		test.AssertEquals(t, prob.Type, tc.expected)
+		test.AssertEquals(t, prob.Detail, tc.err.Error())
 	}
 }


### PR DESCRIPTION
This is LLM-written by Fable; you might want to just discard this and take another implementation approach.

Fixes #9018 