### PR TITLE
ci: remove minio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,10 +68,6 @@ services:
         condition: service_started
       bpkimetal:
         condition: service_started
-      bminio:
-        condition: service_healthy
-      bsunlight:
-        condition: service_started
     entrypoint: test/entrypoint.sh
     working_dir: &boulder_working_dir /boulder
 
@@ -154,49 +150,6 @@ services:
       - pkimetal-socket:/var/run/pkimetal
       - ./test/pkimetal-config.yaml:/config/config.yaml:ro
     network_mode: none
-
-  bminio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    volumes:
-      - ./test/minio:/boulder/test/minio/
-      - mtc-data:/data
-    entrypoint:
-      - /boulder/test/minio/entrypoint.sh
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
-      MINIO_DOMAIN: boulder-minio
-    healthcheck:
-      test: [ "CMD", "curl", "-fs", "-o", "/dev/null",
-        "http://localhost:9000/boulder-mtc-tiles/index.html" ]
-      start_period: 30s
-      start_interval: 0.1s
-      interval: 30s
-      timeout: 2s
-      retries: 3
-    networks:
-      bouldernet:
-        aliases:
-          - boulder-minio
-          - boulder-sunlight.boulder-minio
-
-  bsunlight:
-    image: letsencrypt/boulder-sunlight:${BOULDER_SUNLIGHT_TAG:-latest}
-    build:
-      context: test/sunlight/
-    depends_on:
-      bminio:
-        condition: service_healthy
-    volumes:
-      - .:/boulder:cached
-      - mtc-data:/sunlight-data
-    environment:
-      AWS_ACCESS_KEY_ID: minioadmin
-      AWS_SECRET_ACCESS_KEY: minioadmin
-    networks:
-      bouldernet:
-        aliases:
-          - bsunlight
 
   bvitess:
     # The `letsencrypt/boulder-vtcomboserver:latest` tag is automatically built

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -187,6 +187,7 @@ func TestIssuanceProfiles(t *testing.T) {
 
 // TestIssuanceMTC issues from an MTC profile.
 func TestIssuanceMTC(t *testing.T) {
+	t.Skip("temporarily disabled until an S3 backend is available in CI again")
 	t.Parallel()
 	if os.Getenv("BOULDER_CONFIG_DIR") != "test/config-next" {
 		t.Skip("MTC issuance only available in config-next")

--- a/test/startservers.py
+++ b/test/startservers.py
@@ -142,18 +142,6 @@ SERVICES = [
         None),
 ]
 
-if CONFIG_NEXT:
-    SERVICES.extend([
-        Service('boulder-mtca-1',
-            8010, 9396, 'mtca.boulder',
-            ('./bin/boulder', 'boulder-mtca', '--config', os.path.join(config_dir, 'mtca.json'), '--addr', ':9396', '--debug-addr', ':8010', '-init-log-for-test'),
-            None),
-        Service('boulder-mtpublisher-1',
-            8025, None, None,
-            ('./bin/boulder', 'boulder-mtpublisher', '--config', os.path.join(config_dir, 'mtpublisher.json'), '--debug-addr', ':8025'),
-            None),
-    ])
-
 def _service_toposort(services):
     """Yields Service objects in topologically sorted order.
 


### PR DESCRIPTION
The container on Docker Hub disappeared, breaking our CI. We'll find a new tool to fill this role, but in the meantime, CI must work.

Also remove the components that depend on minio it from our CI environment. These are all MTC-related and not yet deployed, so temporarily removing their tests from CI is okay.