### PR TITLE
ci: use the minio container from quay.io.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,7 @@ services:
     network_mode: none
 
   bminio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     volumes:
       - ./test/minio:/boulder/test/minio/
       - mtc-data:/data


### PR DESCRIPTION
This could give us some more time to plan a replacement for the `minio` container that has been removed from dockerhub.